### PR TITLE
Update gitignore for temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # Node
 node_modules/
+frontend/node_modules/
 
 # Environments
 .env
@@ -12,4 +13,9 @@ venv/
 
 # Build artifacts
 frontend/dist/
+dist/
+build/
 
+# Logs and OS files
+*.log
+.DS_Store


### PR DESCRIPTION
## Summary
- improve `.gitignore` to exclude `node_modules`, build artifacts and temp files
- removed any leftover `frontend/node_modules` directory (none existed)

## Testing
- `find backend -name '*.py' -print0 | xargs -0 python -m py_compile`