### PR TITLE
Add API-only entry point

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+from typing import List
+
+# Reuse the data models and handlers from the full application
+from backend.app.main import (
+    KPI,
+    CalculationRequest,
+    CalculationResponse,
+    get_kpis,
+    calculate,
+)
+
+app = FastAPI(title="Catona API")
+
+# Register the minimal API routes
+app.add_api_route(
+    "/api/kpis",
+    get_kpis,
+    methods=["GET"],
+    response_model=List[KPI],
+)
+
+app.add_api_route(
+    "/api/calculate",
+    calculate,
+    methods=["POST"],
+    response_model=CalculationResponse,
+)


### PR DESCRIPTION
## Summary
- add `backend/main.py` that exposes `/api/kpis` and `/api/calculate`
- attempt to run tests

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*