### PR TITLE
Improve CORS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ If you only need a static preview without API functionality you can still run
 `python3 -m http.server 8000` and open `frontend/index.html`, but the API calls
 will fail in that mode.
 
+### Environment Variables
+
+The CORS middleware reads three optional variables to control allowed origins,
+methods and headers:
+
+```
+CORS_ALLOW_ORIGINS  # e.g. "http://localhost:3000" (default)
+CORS_ALLOW_METHODS  # comma separated, default "GET,POST"
+CORS_ALLOW_HEADERS  # comma separated, default "Content-Type"
+```
+
+The provided defaults work well for development. In production set these
+variables to match your deployed frontend host and any additional requirements.
+
 ## Running Tests
 
 ### Backend

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import os
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
@@ -8,11 +9,15 @@ from typing import List
 
 app = FastAPI(title="Catona Dashboard")
 
+origins = os.getenv("CORS_ALLOW_ORIGINS", "http://localhost:3000").split(",")
+methods = os.getenv("CORS_ALLOW_METHODS", "GET,POST").split(",")
+headers = os.getenv("CORS_ALLOW_HEADERS", "Content-Type").split(",")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"]
+    allow_origins=[origin.strip() for origin in origins],
+    allow_methods=[method.strip() for method in methods],
+    allow_headers=[header.strip() for header in headers],
 )
 
 app.mount("/static", StaticFiles(directory="static"), name="static")


### PR DESCRIPTION
## Summary
- configure CORS middleware using explicit allow lists
- document environment variables for CORS configuration in README

## Testing
- `pytest -q` *(fails: command not found)*