### PR TITLE
Add debug report script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,8 @@ uvicorn backend.app.main:app
 ```
 
 When the `frontend/dist` folder is present the backend automatically serves `index.html` and asset files from that directory.
+
+## Debug Report
+
+Run `python tools/debug_report.py` to print helpful environment information. The script reports the Python version, installed packages, Node and npm versions, and values of key environment variables such as `CORS_ALLOW_ORIGINS`. The output is plain text so it can be easily copied into bug reports.
+

--- a/tools/debug_report.py
+++ b/tools/debug_report.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+import sys
+
+
+def run_command(cmd):
+    """Run a command and return its output or an error message."""
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=True)
+        return result.stdout.strip()
+    except Exception as exc:
+        return f"Error running {' '.join(cmd)}: {exc}"
+
+
+def main():
+    print("== Python Version ==")
+    print(sys.version)
+    print()
+
+    print("== Installed Packages ==")
+    print(run_command(['pip', 'freeze']))
+    print()
+
+    print("== Node Version ==")
+    print(run_command(['node', '--version']))
+    print()
+
+    print("== npm Version ==")
+    print(run_command(['npm', '--version']))
+    print()
+
+    env_vars = [
+        'CORS_ALLOW_ORIGINS',
+        'CORS_ALLOW_METHODS',
+        'CORS_ALLOW_HEADERS'
+    ]
+    print("== Environment Variables ==")
+    for var in env_vars:
+        print(f"{var}={os.getenv(var, '')}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add tools/debug_report.py for collecting environment details
- document how to use the debug report in the README

## Testing
- `pytest -q` *(fails: command not found)*
- `python tools/debug_report.py | head`