### PR TITLE
Update port and chart display

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ installed.
    the project resides in a protected location; moving the repository to a
    regular folder such as `~/financial-modeling-tool` resolves this.
 7. **Open the app**
-   Visit [http://localhost:8000/](http://localhost:8000/)
+   Visit [http://localhost:8001/](http://localhost:8001/)
 
-The command above starts the API and serves the frontend at `http://localhost:8000/`. It also exposes `/api/kpis` and `/api/calculate` for the dashboard.
+The command above starts the API and serves the frontend at `http://localhost:8001/`. It also exposes `/api/kpis` and `/api/calculate` for the dashboard.
 
 The old static prototype located at `templates/index.html` has been removed so the project only has one entry point.
 
 If you only need a static preview without API functionality you can still run
-`python3 -m http.server 8000` and open `frontend/index.html`, but the API calls
+`python3 -m http.server 8001` and open `frontend/index.html`, but the API calls
 will fail in that mode.
 
 ## Deployment
@@ -75,10 +75,10 @@ cd ..
 Starting the server normally will then use the bundled files in `frontend/dist`:
 
 ```bash
-uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
+uvicorn backend.app.main:app --host 0.0.0.0 --port 8001
 # or if started from another directory
-# PYTHONPATH=. uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
-# python3 -m uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
+# PYTHONPATH=. uvicorn backend.app.main:app --host 0.0.0.0 --port 8001
+# python3 -m uvicorn backend.app.main:app --host 0.0.0.0 --port 8001
 ```
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -73,11 +73,25 @@ class CalculationResponse(BaseModel):
 
 @app.get("/api/kpis", response_model=List[KPI])
 async def get_kpis():
+    tier_revenues = [1000, 2500, 5000, 10000]
+    marketing_budget = 5000
+    cpl = 50
+    conversion_rate = 0.1
+    churn = 0.05
+    months = 24
+    customers = 10.0
+    monthly_acquisition = (marketing_budget / max(cpl, 1)) * conversion_rate
+    avg_rev = sum(tier_revenues) / len(tier_revenues)
+    for _ in range(months):
+        customers = max(0.0, customers * (1 - churn) + monthly_acquisition)
+    total_mrr = customers * avg_rev
+    annual_revenue = total_mrr * 12
+    ltv = avg_rev / churn if churn else 0
     data = [
-        KPI(name="Total MRR", value=256000),
-        KPI(name="Annual Revenue", value=998000),
-        KPI(name="Customer LTV", value=2000),
-        KPI(name="Active Users", value=35)
+        KPI(name="Total MRR", value=round(total_mrr, 2)),
+        KPI(name="Annual Revenue", value=round(annual_revenue, 2)),
+        KPI(name="Customer LTV", value=round(ltv, 2)),
+        KPI(name="Active Users", value=round(customers, 2)),
     ]
     return data
 

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -121,7 +121,15 @@ export default function Dashboard() {
               labels,
               datasets: [{ data: mrrArr, borderColor: '#486BFE', backgroundColor: '#486BFE20', fill: true, tension: 0.3 }],
             },
-            options: { plugins: { legend: { display: false } }, responsive: true, maintainAspectRatio: false },
+            options: {
+              plugins: { legend: { display: false } },
+              responsive: true,
+              maintainAspectRatio: false,
+              scales: {
+                x: { ticks: { font: { size: 10 } } },
+                y: { ticks: { font: { size: 10 } } },
+              },
+            },
           });
         } else {
           const ch = chartInstances.current.mrr;
@@ -142,7 +150,15 @@ export default function Dashboard() {
               labels,
               datasets: [{ data: custArr, borderColor: '#8262FF', backgroundColor: '#8262FF20', fill: true, tension: 0.3 }],
             },
-            options: { plugins: { legend: { display: false } }, responsive: true, maintainAspectRatio: false },
+            options: {
+              plugins: { legend: { display: false } },
+              responsive: true,
+              maintainAspectRatio: false,
+              scales: {
+                x: { ticks: { font: { size: 10 } } },
+                y: { ticks: { font: { size: 10 } } },
+              },
+            },
           });
         } else {
           const ch = chartInstances.current.cust;
@@ -163,7 +179,11 @@ export default function Dashboard() {
               labels: ['Tier 1', 'Tier 2', 'Tier 3', 'Tier 4'],
               datasets: [{ data: tierArr, backgroundColor: ['#486BFE', '#8262FF', '#D19BEA', '#6EE26A'] }],
             },
-            options: { responsive: true, maintainAspectRatio: false },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: { legend: { labels: { font: { size: 10 } } } },
+            },
           });
         } else {
           const ch = chartInstances.current.tier;
@@ -274,12 +294,15 @@ export default function Dashboard() {
             )}
           </div>
           <div className="p-4 bg-white rounded shadow" style={{ height: '200px' }}>
+            <h3 className="text-sm mb-2">Monthly Recurring Revenue</h3>
             <canvas ref={mrrRef}></canvas>
           </div>
           <div className="p-4 bg-white rounded shadow" style={{ height: '200px' }}>
+            <h3 className="text-sm mb-2">Active Customers</h3>
             <canvas ref={custRef}></canvas>
           </div>
           <div className="p-4 bg-white rounded shadow" style={{ height: '200px' }}>
+            <h3 className="text-sm mb-2">Revenue by Tier</h3>
             <canvas ref={tierRef}></canvas>
           </div>
         </div>

--- a/frontend/src/model/subscription.ts
+++ b/frontend/src/model/subscription.ts
@@ -3,6 +3,9 @@ export interface SubscriptionInput {
   churn_rate_smb: number;
   tier_revenues: number[];
   initial_customers?: number;
+  marketing_budget?: number;
+  cpl?: number;
+  conversion_rate?: number;
 }
 
 export interface SubscriptionResult {
@@ -24,17 +27,24 @@ export interface SubscriptionResult {
 export function runSubscriptionModel(input: SubscriptionInput): SubscriptionResult {
   const months = input.projection_months || 12;
   const churn = input.churn_rate_smb / 100;
-  const growth = 0.05;
+
+  const monthlyAcquisition = input.marketing_budget && input.cpl && input.conversion_rate
+    ? (input.marketing_budget / Math.max(input.cpl, 1)) * (input.conversion_rate / 100)
+    : 0;
 
   const monthLabels = Array.from({ length: months }, (_, i) => `M${i + 1}`);
   let customers = input.initial_customers || 10;
   const customers_by_month: number[] = [];
   const mrr_by_month: number[] = [];
 
+  const avgRevenuePerCustomer =
+    input.tier_revenues.reduce((sum, rev) => sum + rev, 0) /
+    (input.tier_revenues.length || 1);
+
   for (let i = 0; i < months; i++) {
-    customers = Math.max(0, customers * (1 + growth - churn));
+    customers = Math.max(0, customers * (1 - churn) + monthlyAcquisition);
     customers_by_month.push(Math.round(customers));
-    const mrr = input.tier_revenues.reduce((sum, rev) => sum + rev, 0);
+    const mrr = customers * avgRevenuePerCustomer;
     mrr_by_month.push(mrr);
   }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://localhost:8000'
+      '/api': 'http://localhost:8001'
     }
   }
 });


### PR DESCRIPTION
## Summary
- show API on port 8001
- proxy frontend dev server to port 8001
- add titles and smaller fonts for dashboard charts
- factor marketing assumptions into subscription model
- compute KPIs using updated subscription logic

## Testing
- `pytest -q` *(fails: command not found)*