### PR TITLE
Add health endpoint and status widget

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,12 @@ app.add_middleware(
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 
+@app.get("/api/health")
+async def health():
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
 dist_dir = Path("frontend/dist")
 if dist_dir.exists():
     app.mount("/assets", StaticFiles(directory=dist_dir / "assets"), name="assets")

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ from backend.app.main import (
     KPI,
     CalculationRequest,
     CalculationResponse,
+    health,
     get_kpis,
     calculate,
 )
@@ -26,3 +27,5 @@ app.add_api_route(
     methods=["POST"],
     response_model=CalculationResponse,
 )
+
+app.add_api_route("/api/health", health, methods=["GET"])

--- a/frontend/src/ApiStatus.tsx
+++ b/frontend/src/ApiStatus.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export default function ApiStatus() {
+  const [status, setStatus] = useState<'unknown' | 'ok' | 'error'>('unknown');
+
+  useEffect(() => {
+    fetch('/api/health')
+      .then((res) => res.ok ? res.json() : Promise.reject())
+      .then((data) => {
+        if (data.status === 'ok') setStatus('ok');
+        else setStatus('error');
+      })
+      .catch(() => setStatus('error'));
+  }, []);
+
+  const color = status === 'ok' ? 'text-green-600' : status === 'error' ? 'text-red-600' : 'text-gray-500';
+  const label = status === 'ok' ? 'API Online' : status === 'error' ? 'API Offline' : 'Checking API...';
+
+  return <div className={`text-sm font-medium ${color}`}>{label}</div>;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,12 @@
 import Dashboard from './Dashboard';
+import ApiStatus from './ApiStatus';
 
 export default function App() {
   return (
-    <div className="max-w-6xl mx-auto p-4">
+    <div className="max-w-6xl mx-auto p-4 space-y-4">
+      <div className="flex justify-end">
+        <ApiStatus />
+      </div>
       <Dashboard />
     </div>
   );

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,3 +52,10 @@ async def test_get_kpis():
     data = resp.json()
     assert isinstance(data, list)
     assert data and "name" in data[0]
+
+@pytest.mark.asyncio
+async def test_health_endpoint():
+    async with AsyncClient(app=api_only_app, base_url="http://test") as ac:
+        resp = await ac.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint to backend app and API-only server
- display API status from the frontend using a new `ApiStatus` component
- test new endpoint

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `npm test --silent` in `frontend` *(fails: jest not found)*