### PR TITLE
Refine dashboard layout and add formatting utilities

### DIFF
--- a/frontend/src/ApiStatus.tsx
+++ b/frontend/src/ApiStatus.tsx
@@ -5,7 +5,7 @@ export default function ApiStatus() {
 
   useEffect(() => {
     fetch('/api/health')
-      .then((res) => res.ok ? res.json() : Promise.reject())
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data) => {
         if (data.status === 'ok') setStatus('ok');
         else setStatus('error');
@@ -13,8 +13,15 @@ export default function ApiStatus() {
       .catch(() => setStatus('error'));
   }, []);
 
-  const color = status === 'ok' ? 'text-green-600' : status === 'error' ? 'text-red-600' : 'text-gray-500';
-  const label = status === 'ok' ? 'API Online' : status === 'error' ? 'API Offline' : 'Checking API...';
+  const label =
+    status === 'ok' ? 'API Online' : status === 'error' ? 'API Offline' : 'Checking API...';
+  const classes =
+    'px-2 py-1 text-xs font-medium rounded-full ' +
+    (status === 'ok'
+      ? 'bg-[var(--success-500)] text-[var(--color-neutral-900)]'
+      : status === 'error'
+      ? 'bg-[var(--error-500)] text-white'
+      : 'bg-[var(--color-neutral-200)] text-[var(--color-neutral-900)]');
 
-  return <div className={`text-sm font-medium ${color}`}>{label}</div>;
+  return <span className={classes}>{label}</span>;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,16 @@
+import { useEffect } from 'react';
 import Dashboard from './Dashboard';
-import ApiStatus from './ApiStatus';
+import Header from './components/Header';
+import { setupChartDefaults } from './chartConfig';
 
 export default function App() {
+  useEffect(() => {
+    setupChartDefaults();
+  }, []);
+
   return (
-    <div className="max-w-6xl mx-auto p-4 space-y-4">
-      <div className="flex justify-end">
-        <ApiStatus />
-      </div>
+    <div className="max-w-[72rem] mx-auto px-6 space-y-6">
+      <Header />
       <Dashboard />
     </div>
   );

--- a/frontend/src/chartConfig.ts
+++ b/frontend/src/chartConfig.ts
@@ -1,0 +1,28 @@
+import { Chart } from 'chart.js/auto';
+
+export function setupChartDefaults() {
+  const styles = getComputedStyle(document.documentElement);
+  const gridColor = styles.getPropertyValue('--color-neutral-200') || '#CAC9C5';
+  const textColor = styles.getPropertyValue('--color-neutral-900') || '#1E1D1B';
+  const tooltipBg = styles.getPropertyValue('--color-neutral-900') || '#1E1D1B';
+  const tooltipText = styles.getPropertyValue('--color-neutral-50') || '#FDFCFA';
+
+  Chart.defaults.color = textColor.trim();
+  Chart.defaults.font.family = 'Inter, sans-serif';
+  Chart.defaults.elements.line.borderWidth = 4;
+  Chart.defaults.elements.line.borderCapStyle = 'round';
+  Chart.defaults.elements.line.fill = false;
+  Chart.defaults.elements.bar.borderRadius = 8;
+  Chart.defaults.datasets.bar.categoryPercentage = 0.8;
+  Chart.defaults.plugins.legend.display = false;
+  Chart.defaults.plugins.tooltip.backgroundColor = tooltipBg.trim();
+  Chart.defaults.plugins.tooltip.titleColor = tooltipText.trim();
+  Chart.defaults.plugins.tooltip.bodyColor = tooltipText.trim();
+  Chart.defaults.plugins.tooltip.cornerRadius = 4;
+  Chart.defaults.plugins.tooltip.titleFont = { size: 12 } as any;
+  Chart.defaults.plugins.tooltip.bodyFont = { size: 12 } as any;
+  Chart.defaults.scales = {
+    x: { grid: { display: false, color: gridColor.trim(), lineWidth: 1 } },
+    y: { grid: { color: gridColor.trim(), lineWidth: 1 }, beginAtZero: true },
+  } as any;
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+interface Props { children: ReactNode; className?: string; }
+
+export default function Card({ children, className = '' }: Props) {
+  return (
+    <div className={`bg-[var(--color-neutral-100)] border border-[var(--color-neutral-200)] rounded-lg p-5 ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/ChartCard.tsx
+++ b/frontend/src/components/ChartCard.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+import Card from './Card';
+
+interface Props { title: string; children: ReactNode; loading?: boolean; }
+
+export default function ChartCard({ title, children, loading }: Props) {
+  return (
+    <Card className="relative">
+      <h3 className="text-sm font-medium mb-2">{title}</h3>
+      <div className="h-64 relative">{children}</div>
+      {loading && (
+        <div className="absolute inset-0 bg-white/40 flex items-center justify-center text-sm font-medium">
+          Updating...
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,13 @@
+import ApiStatus from '../ApiStatus';
+
+export default function Header() {
+  return (
+    <header className="flex items-center justify-between py-4">
+      <div>
+        <h1 className="font-bold text-[32px] leading-[1.2]">SMB Program Modeling</h1>
+        <p className="font-medium text-sm leading-[1.4] text-[var(--color-neutral-500)]">Carbon Removal Subscription Service</p>
+      </div>
+      <ApiStatus />
+    </header>
+  );
+}

--- a/frontend/src/components/InputRow.tsx
+++ b/frontend/src/components/InputRow.tsx
@@ -1,0 +1,24 @@
+interface Props {
+  label: string;
+  name: string;
+  value: number;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function InputRow({ label, name, value, onChange }: Props) {
+  return (
+    <div className="grid grid-cols-2 gap-2 items-center">
+      <label htmlFor={name} className="text-xs font-medium text-left">
+        {label}
+      </label>
+      <input
+        id={name}
+        name={name}
+        type="number"
+        value={value}
+        onChange={onChange}
+        className="text-right font-mono border border-[var(--color-neutral-200)] rounded px-2 py-1"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -1,0 +1,10 @@
+interface Props { label: string; value: string | number; }
+
+export default function KPIChip({ label, value }: Props) {
+  return (
+    <div className="bg-[var(--color-neutral-100)] border border-[var(--color-neutral-200)] rounded-lg p-4 text-center">
+      <div className="text-xs font-medium leading-[1.4] text-[var(--color-neutral-500)]">{label}</div>
+      <div className="text-xl font-semibold leading-[1.2] text-[var(--color-neutral-900)]">{value}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/SidePanel.tsx
+++ b/frontend/src/components/SidePanel.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react';
+import Card from './Card';
+
+export default function SidePanel({ children }: { children: ReactNode }) {
+  return <Card className="space-y-4">{children}</Card>;
+}

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -1,0 +1,19 @@
+import { formatCurrency, formatPercentage, formatNumberShort } from './format';
+
+test('format currency millions', () => {
+  expect(formatCurrency(1270000)).toBe('$1.27 M');
+});
+
+test('format currency thousands', () => {
+  expect(formatCurrency(7900)).toBe('$7.9 k');
+});
+
+test('format currency small', () => {
+  expect(formatCurrency(500)).toBe('$500');
+});
+
+test('percentage tolerance', () => {
+  const val = 0.1234;
+  const pct = parseFloat(formatPercentage(val));
+  expect(Math.abs(pct - 12.34)).toBeLessThanOrEqual(12.34 * 0.005);
+});

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,16 @@
+export function formatNumberShort(value: number): string {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(2)} M`;
+  } else if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)} k`;
+  }
+  return value.toLocaleString();
+}
+
+export function formatCurrency(value: number): string {
+  return '$' + formatNumberShort(value);
+}
+
+export function formatPercentage(value: number): string {
+  return `${(value * 100).toFixed(1)} %`;
+}


### PR DESCRIPTION
## Summary
- centralize Chart.js defaults
- add reusable UI components (Header, Card, KPIChip, ChartCard, SidePanel, InputRow)
- update layout and KPI formatting
- show pill status for API connectivity
- add number formatting helpers with tests

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `cd frontend && npm test --silent` *(fails: jest not found)*