### PR TITLE
Fix duplicate Path import

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,6 @@ except Exception:  # Jinja2 may not be installed
 from pathlib import Path
 from pydantic import BaseModel
 from typing import List
-from pathlib import Path
 
 app = FastAPI(title="Catona Dashboard")
 


### PR DESCRIPTION
## Summary
- remove redundant `Path` import in backend app

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find jinja2)*
- `pytest -q` *(fails: command not found)*