### PR TITLE
Fix fetch mock for tests

### DIFF
--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 
 global.fetch = jest.fn(() =>
   Promise.resolve({
+    ok: true,
     json: () => Promise.resolve([]),
   })
 ) as jest.Mock;


### PR DESCRIPTION
## Summary
- add `ok: true` to fetch mock so API calls succeed

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `npm test --silent` *(fails: jest: not found)*