### PR TITLE
Add external chart legend display

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -63,6 +63,8 @@ export default function Dashboard() {
 
   const [metrics, setMetrics] = useState<Metrics | null>(null);
   const [projections, setProjections] = useState<{ mrr: number[]; customers: number[] }>({ mrr: [], customers: [] });
+  const [combinedLegend, setCombinedLegend] = useState<string>('');
+  const [tierLegend, setTierLegend] = useState<string>('');
   const mrrCustRef = useRef<HTMLCanvasElement>(null);
   const tierRef = useRef<HTMLCanvasElement>(null);
   const chartInstances = useRef<{ combined?: Chart; tier?: Chart }>({});
@@ -131,6 +133,7 @@ export default function Dashboard() {
             options: {
               responsive: true,
               maintainAspectRatio: false,
+              plugins: { legend: { display: false } },
               scales: {
                 y1: { position: 'left' },
                 y2: { position: 'right' },
@@ -143,6 +146,9 @@ export default function Dashboard() {
           (ch.data.datasets[0].data as number[]) = mrrArr;
           (ch.data.datasets[1].data as number[]) = custArr;
           ch.update();
+        }
+        if (chartInstances.current.combined) {
+          setCombinedLegend(chartInstances.current.combined.generateLegend());
         }
       }
     }
@@ -162,6 +168,7 @@ export default function Dashboard() {
             options: {
               responsive: true,
               maintainAspectRatio: false,
+              plugins: { legend: { display: false } },
               scales: { x: { stacked: true }, y: { stacked: true } },
             },
           });
@@ -170,6 +177,9 @@ export default function Dashboard() {
           ch.data.labels = labels;
           ch.data.datasets = datasets as any;
           ch.update();
+        }
+        if (chartInstances.current.tier) {
+          setTierLegend(chartInstances.current.tier.generateLegend());
         }
       }
     }
@@ -242,10 +252,10 @@ export default function Dashboard() {
           </SidePanel>
         </div>
         <div className="col-span-12 lg:col-span-9 space-y-4">
-          <ChartCard title="MRR & Customers">
+          <ChartCard title="MRR & Customers" legend={combinedLegend}>
             <canvas ref={mrrCustRef}></canvas>
           </ChartCard>
-          <ChartCard title="Revenue by Tier">
+          <ChartCard title="Revenue by Tier" legend={tierLegend}>
             <canvas ref={tierRef}></canvas>
           </ChartCard>
         </div>

--- a/frontend/src/chartConfig.ts
+++ b/frontend/src/chartConfig.ts
@@ -15,7 +15,7 @@ export function setupChartDefaults() {
   Chart.defaults.elements.line.pointRadius = 0;
   Chart.defaults.elements.bar.borderRadius = 8;
   Chart.defaults.datasets.bar.categoryPercentage = 0.8;
-  Chart.defaults.plugins.legend.display = false;
+  Chart.defaults.plugins.legend.display = true;
   Chart.defaults.plugins.tooltip.backgroundColor = tooltipBg.trim();
   Chart.defaults.plugins.tooltip.titleColor = tooltipText.trim();
   Chart.defaults.plugins.tooltip.bodyColor = tooltipText.trim();

--- a/frontend/src/components/ChartCard.tsx
+++ b/frontend/src/components/ChartCard.tsx
@@ -1,12 +1,26 @@
 import { ReactNode } from 'react';
 import Card from './Card';
 
-interface Props { title: string; children: ReactNode; }
+interface Props {
+  title: string;
+  children: ReactNode;
+  legend?: string | ReactNode;
+}
 
-export default function ChartCard({ title, children }: Props) {
+export default function ChartCard({ title, children, legend }: Props) {
   return (
     <div>
-      <h3 className="text-sm font-medium mb-2 font-sans">{title}</h3>
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="text-sm font-medium font-sans">{title}</h3>
+        {legend && (
+          <div
+            className="text-xs font-mono text-[var(--squid-ink)]"
+            {...(typeof legend === 'string' ? { dangerouslySetInnerHTML: { __html: legend } } : {})}
+          >
+            {typeof legend === 'string' ? null : legend}
+          </div>
+        )}
+      </div>
       <Card className="relative">
         <div className="h-64 relative">{children}</div>
       </Card>


### PR DESCRIPTION
## Summary
- enable legends in chart defaults
- allow external legend rendering via ChartCard
- display legend inside ChartCard header using flex layout

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: command not found)*