### PR TITLE
Fix KPI chip sizing

### DIFF
--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -8,10 +8,10 @@ interface Props {
 
 export default function KPIChip({ label, value, sparkData }: Props) {
   return (
-    <div className="bg-[var(--color-neutral-50)] border border-[var(--color-neutral-200)] rounded-lg p-4 flex items-center">
+    <div className="bg-[var(--color-neutral-50)] border border-[var(--color-neutral-200)] rounded-lg px-4 py-3 flex items-center">
       <div className="w-1/3 text-left">
-        <div className="text-base font-medium leading-[1.4] text-[var(--color-neutral-500)]">{label}</div>
-        <div className="text-3xl font-semibold leading-[1.2] text-[var(--color-neutral-900)]">{value}</div>
+        <div className="text-sm font-medium leading-[1.4] text-[var(--color-neutral-500)]">{label}</div>
+        <div className="text-2xl font-semibold leading-[1.2] text-[var(--color-neutral-900)]">{value}</div>
       </div>
       <div className="w-2/3 h-10">
         <Sparkline data={sparkData} />


### PR DESCRIPTION
## Summary
- reduce KPI chip label/value font sizes
- tweak KPI chip padding to avoid sparkline overlap

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `npm test --silent` *(fails: jest not found)*