### PR TITLE
Add gradient wipe to sparkline

### DIFF
--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from 'react';
 import { Chart } from 'chart.js/auto';
+import gradientWipe from '../plugins/gradientWipe';
 
 export default function Sparkline({ data }: { data: number[] }) {
   const ref = useRef<HTMLCanvasElement>(null);
@@ -9,15 +10,17 @@ export default function Sparkline({ data }: { data: number[] }) {
     if (!ref.current) return;
     const labels = data.map((_, i) => i.toString());
     if (!chartRef.current) {
+      Chart.register(gradientWipe);
       chartRef.current = new Chart(ref.current, {
         type: 'line',
-        data: { labels, datasets: [{ data, borderColor: 'var(--accent-primary-500)', borderWidth: 2, pointRadius: 0 }] },
+        data: { labels, datasets: [{ data, borderColor: 'var(--cobalt-500)', borderWidth: 4, pointRadius: 0 }] },
         options: {
           responsive: true,
           maintainAspectRatio: false,
           scales: { x: { display: false }, y: { display: false } },
           plugins: { legend: { display: false }, tooltip: { enabled: false } },
         },
+        plugins: [gradientWipe],
       });
     } else {
       const c = chartRef.current;
@@ -27,5 +30,5 @@ export default function Sparkline({ data }: { data: number[] }) {
     }
   }, [data]);
 
-  return <canvas ref={ref} className="w-full h-8" />;
+  return <canvas ref={ref} className="w-full h-8 sparkline-gradient" />;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,3 +9,13 @@
 }
 body { background-color: var(--Pearl); font-family: 'Roboto Mono', monospace; color: var(--squid-ink); }
 h1,h2,h3,h4,h5,h6 { font-family: 'Inter', sans-serif; }
+
+.sparkline-gradient {
+  --wipe-offset: 0;
+  animation: wipe 4s linear infinite;
+}
+
+@keyframes wipe {
+  0% { --wipe-offset: 0; }
+  100% { --wipe-offset: 1; }
+}

--- a/frontend/src/plugins/gradientWipe.ts
+++ b/frontend/src/plugins/gradientWipe.ts
@@ -1,0 +1,29 @@
+import { Chart } from 'chart.js/auto';
+
+const gradientWipe = {
+  id: 'gradientWipe',
+  afterDatasetsDraw(chart: Chart) {
+    const { ctx, chartArea } = chart;
+    if (!chartArea) return;
+    const styles = getComputedStyle(chart.canvas);
+    const offsetStr = styles.getPropertyValue('--wipe-offset');
+    const offset = parseFloat(offsetStr) || 0;
+    const width = chartArea.right - chartArea.left;
+    const height = chartArea.bottom - chartArea.top;
+    const gradWidth = width / 3;
+    const x = chartArea.left + width * offset - gradWidth / 2;
+
+    const gradient = ctx.createLinearGradient(x, 0, x + gradWidth, 0);
+    gradient.addColorStop(0, 'transparent');
+    gradient.addColorStop(0.5, 'var(--cobalt-500)');
+    gradient.addColorStop(1, 'transparent');
+
+    ctx.save();
+    ctx.globalCompositeOperation = 'source-atop';
+    ctx.fillStyle = gradient;
+    ctx.fillRect(chartArea.left, chartArea.top, width, height);
+    ctx.restore();
+  },
+};
+
+export default gradientWipe;

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -435,3 +435,13 @@ input[type=number] {
     grid-template-columns: repeat(3, 1fr);
   }
 }
+
+.sparkline-gradient {
+  --wipe-offset: 0;
+  animation: wipe 4s linear infinite;
+}
+
+@keyframes wipe {
+  0% { --wipe-offset: 0; }
+  100% { --wipe-offset: 1; }
+}


### PR DESCRIPTION
## Summary
- update Sparkline to use Cobalt and thicker border
- create Chart.js gradient wipe plugin
- use new plugin in Sparkline
- animate wipe with CSS

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: jest not found)*