### PR TITLE
Add gradient wipe to sparkline

### DIFF
--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Sparkline from './Sparkline';
 
 interface Props {
@@ -7,14 +8,19 @@ interface Props {
 }
 
 export default function KPIChip({ label, value, sparkData }: Props) {
+  const [active, setActive] = useState(false);
   return (
-    <div className="bg-[var(--color-neutral-50)] border border-[var(--color-neutral-200)] rounded-lg p-4 flex items-center">
+    <div
+      onMouseEnter={() => setActive(true)}
+      onMouseLeave={() => setActive(false)}
+      className="bg-[var(--color-neutral-50)] border border-[var(--color-neutral-200)] rounded-lg p-4 flex items-center"
+    >
       <div className="w-1/3 text-left">
         <div className="text-base font-medium leading-[1.4] text-[var(--color-neutral-500)]">{label}</div>
         <div className="text-3xl font-semibold leading-[1.2] text-[var(--color-neutral-900)]">{value}</div>
       </div>
       <div className="w-2/3 h-10">
-        <Sparkline data={sparkData} />
+        <Sparkline data={sparkData} active={active} />
       </div>
     </div>
   );

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,23 +1,29 @@
 import { useRef, useEffect } from 'react';
 import { Chart } from 'chart.js/auto';
+import gradientWipe from '../plugins/gradientWipe';
 
-export default function Sparkline({ data }: { data: number[] }) {
+export default function Sparkline({ data, active = false }: { data: number[]; active?: boolean }) {
   const ref = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart>();
+  const animRef = useRef<number>();
 
   useEffect(() => {
     if (!ref.current) return;
+    ref.current.style.setProperty('--wipe-offset', '0');
+    ref.current.style.setProperty('--wipe-opacity', '0');
     const labels = data.map((_, i) => i.toString());
     if (!chartRef.current) {
+      Chart.register(gradientWipe);
       chartRef.current = new Chart(ref.current, {
         type: 'line',
-        data: { labels, datasets: [{ data, borderColor: 'var(--accent-primary-500)', borderWidth: 2, pointRadius: 0 }] },
+        data: { labels, datasets: [{ data, borderColor: 'var(--cobalt-500)', borderWidth: 4, pointRadius: 0 }] },
         options: {
           responsive: true,
           maintainAspectRatio: false,
           scales: { x: { display: false }, y: { display: false } },
           plugins: { legend: { display: false }, tooltip: { enabled: false } },
         },
+        plugins: [gradientWipe],
       });
     } else {
       const c = chartRef.current;
@@ -27,5 +33,41 @@ export default function Sparkline({ data }: { data: number[] }) {
     }
   }, [data]);
 
-  return <canvas ref={ref} className="w-full h-8" />;
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const duration = 2000;
+    const fadeTime = 500;
+    let raf: number;
+
+    const animate = (t: number) => {
+      const progress = (t % duration) / duration;
+      el.style.setProperty('--wipe-offset', progress.toString());
+      raf = requestAnimationFrame(animate);
+    };
+
+    const fade = (start: number, ts: number) => {
+      const p = (ts - start) / fadeTime;
+      const o = Math.max(0, 1 - p);
+      el.style.setProperty('--wipe-opacity', o.toString());
+      if (p < 1) {
+        raf = requestAnimationFrame((newTs) => fade(start, newTs));
+      } else {
+        el.style.setProperty('--wipe-offset', '0');
+      }
+    };
+
+    if (active) {
+      el.style.setProperty('--wipe-opacity', '1');
+      raf = requestAnimationFrame(animate);
+    } else {
+      if (animRef.current) cancelAnimationFrame(animRef.current);
+      const start = performance.now();
+      raf = requestAnimationFrame((ts) => fade(start, ts));
+    }
+    animRef.current = raf;
+    return () => cancelAnimationFrame(raf);
+  }, [active]);
+
+  return <canvas ref={ref} className={`w-full h-8 sparkline-gradient${active ? ' sparkline-wipe' : ''}`} />;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,3 +9,18 @@
 }
 body { background-color: var(--Pearl); font-family: 'Roboto Mono', monospace; color: var(--squid-ink); }
 h1,h2,h3,h4,h5,h6 { font-family: 'Inter', sans-serif; }
+
+.sparkline-gradient {
+  --wipe-offset: 0;
+  --wipe-opacity: 0;
+}
+
+.sparkline-wipe {
+  animation: wipe 2s linear infinite;
+  --wipe-opacity: 1;
+}
+
+@keyframes wipe {
+  0% { --wipe-offset: 0; }
+  100% { --wipe-offset: 1; }
+}

--- a/frontend/src/plugins/gradientWipe.ts
+++ b/frontend/src/plugins/gradientWipe.ts
@@ -1,0 +1,34 @@
+import { Chart } from 'chart.js/auto';
+
+const gradientWipe = {
+  id: 'gradientWipe',
+  afterDatasetsDraw(chart: Chart) {
+    const { ctx, chartArea } = chart;
+    if (!chartArea) return;
+    const styles = getComputedStyle(chart.canvas);
+    const offsetStr = styles.getPropertyValue('--wipe-offset');
+    const opacityStr = styles.getPropertyValue('--wipe-opacity');
+    const offset = parseFloat(offsetStr) || 0;
+    const opacity = parseFloat(opacityStr) || 0;
+    if (opacity <= 0) return;
+
+    const width = chartArea.right - chartArea.left;
+    const height = chartArea.bottom - chartArea.top;
+    const gradWidth = width / 3;
+    const x = chartArea.left + width * offset - gradWidth / 2;
+
+    const gradient = ctx.createLinearGradient(x, 0, x + gradWidth, 0);
+    gradient.addColorStop(0, 'transparent');
+    gradient.addColorStop(0.5, 'var(--cobalt-500)');
+    gradient.addColorStop(1, 'transparent');
+
+    ctx.save();
+    ctx.globalAlpha = Math.min(1, Math.max(0, opacity));
+    ctx.globalCompositeOperation = 'source-atop';
+    ctx.fillStyle = gradient;
+    ctx.fillRect(chartArea.left, chartArea.top, width, height);
+    ctx.restore();
+  },
+};
+
+export default gradientWipe;

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -435,3 +435,18 @@ input[type=number] {
     grid-template-columns: repeat(3, 1fr);
   }
 }
+
+.sparkline-gradient {
+  --wipe-offset: 0;
+  --wipe-opacity: 0;
+}
+
+.sparkline-wipe {
+  animation: wipe 2s linear infinite;
+  --wipe-opacity: 1;
+}
+
+@keyframes wipe {
+  0% { --wipe-offset: 0; }
+  100% { --wipe-offset: 1; }
+}


### PR DESCRIPTION
## Summary
- update KPIChip to trigger sparkline animation on hover
- animate wipe for only hovered chip and fade on mouse out
- adjust gradient wipe plugin to honor opacity variable
- use 2s wipe animation timing

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(command not found)*