### PR TITLE
Add KPI sparkline flash effect

### DIFF
--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export default function KPIChip({ label, value, sparkData }: Props) {
   return (
-    <div className="bg-[var(--color-neutral-50)] border border-[var(--color-neutral-200)] rounded-lg px-4 py-3 flex items-center">
+    <div className="kpi-chip bg-[var(--color-neutral-50)] border border-[var(--color-neutral-200)] rounded-lg px-4 py-3 flex items-center">
       <div className="w-1/3 text-left">
         <div className="text-sm font-medium leading-[1.4] text-[var(--color-neutral-500)]">{label}</div>
         <div className="text-2xl font-semibold leading-[1.2] text-[var(--color-neutral-900)]">{value}</div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,10 +12,23 @@ h1,h2,h3,h4,h5,h6 { font-family: 'Inter', sans-serif; }
 
 .sparkline-gradient {
   --wipe-offset: 0;
-  animation: wipe 4s linear infinite;
+  --flash-opacity: 0;
+  opacity: 0;
+  transition: opacity var(--transition-normal);
+  animation: none;
+}
+
+.kpi-chip:hover .sparkline-gradient {
+  animation: flash 0.4s ease-out, wipe 4s linear infinite 0.4s;
+  opacity: 1;
 }
 
 @keyframes wipe {
   0% { --wipe-offset: 0; }
   100% { --wipe-offset: 1; }
+}
+
+@keyframes flash {
+  0% { --flash-opacity: 0.6; }
+  100% { --flash-opacity: 0; }
 }

--- a/frontend/src/plugins/gradientWipe.ts
+++ b/frontend/src/plugins/gradientWipe.ts
@@ -7,7 +7,9 @@ const gradientWipe = {
     if (!chartArea) return;
     const styles = getComputedStyle(chart.canvas);
     const offsetStr = styles.getPropertyValue('--wipe-offset');
+    const flashStr = styles.getPropertyValue('--flash-opacity');
     const offset = parseFloat(offsetStr) || 0;
+    const flash = parseFloat(flashStr) || 0;
     const width = chartArea.right - chartArea.left;
     const height = chartArea.bottom - chartArea.top;
     const gradWidth = width / 3;
@@ -22,6 +24,14 @@ const gradientWipe = {
     ctx.globalCompositeOperation = 'source-atop';
     ctx.fillStyle = gradient;
     ctx.fillRect(chartArea.left, chartArea.top, width, height);
+
+    if (flash > 0) {
+      ctx.globalAlpha = flash;
+      ctx.fillStyle = 'var(--cobalt-500)';
+      ctx.fillRect(chartArea.left, chartArea.top, width, height);
+      ctx.globalAlpha = 1;
+    }
+
     ctx.restore();
   },
 };


### PR DESCRIPTION
## Summary
- add `kpi-chip` class wrapper for KPI chips
- implement CSS animations for flash and looping gradient wipe
- modify Chart.js plugin to use `--flash-opacity`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `npm test --silent` *(fails: jest not found)*