### PR TITLE
Fix legend generation

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -19,6 +19,7 @@ import SidePanel from './components/SidePanel';
 import InputRow from './components/InputRow';
 import ChartCard from './components/ChartCard';
 import { formatCurrency, formatNumberShort } from './utils/format';
+import { generateLegend } from './utils/chartLegend';
 
 interface FormState {
   tier1_revenue: number;
@@ -148,7 +149,7 @@ export default function Dashboard() {
           ch.update();
         }
         if (chartInstances.current.combined) {
-          setCombinedLegend(chartInstances.current.combined.generateLegend());
+          setCombinedLegend(generateLegend(chartInstances.current.combined));
         }
       }
     }
@@ -179,7 +180,7 @@ export default function Dashboard() {
           ch.update();
         }
         if (chartInstances.current.tier) {
-          setTierLegend(chartInstances.current.tier.generateLegend());
+          setTierLegend(generateLegend(chartInstances.current.tier));
         }
       }
     }

--- a/frontend/src/utils/chartLegend.ts
+++ b/frontend/src/utils/chartLegend.ts
@@ -1,0 +1,11 @@
+export function generateLegend(chart: import('chart.js').Chart): string {
+  const { datasets } = chart.data;
+  const items = datasets.map((ds: any) => {
+    const color = ds.borderColor || ds.backgroundColor || '#000';
+    const label = ds.label || '';
+    return `<span style="display:inline-flex;align-items:center;margin-right:8px;">
+      <span style="background-color:${color};width:10px;height:10px;display:inline-block;margin-right:4px;"></span>${label}
+    </span>`;
+  });
+  return items.join('');
+}


### PR DESCRIPTION
## Summary
- add a small utility to create chart legends
- use new legend generator in Dashboard instead of removed Chart.js method

## Testing
- `npm test --silent` *(fails: `jest: not found`)*
- `pytest -q` *(fails: `pytest: command not found`)*