### PR TITLE
Fix legend generation

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -19,6 +19,7 @@ import SidePanel from './components/SidePanel';
 import InputRow from './components/InputRow';
 import ChartCard from './components/ChartCard';
 import { formatCurrency, formatNumberShort } from './utils/format';
+import { generateLegend } from './utils/chartLegend';
 
 interface FormState {
   tier1_revenue: number;
@@ -148,7 +149,7 @@ export default function Dashboard() {
           ch.update();
         }
         if (chartInstances.current.combined) {
-          setCombinedLegend(chartInstances.current.combined.generateLegend());
+          setCombinedLegend(generateLegend(chartInstances.current.combined));
         }
       }
     }
@@ -179,7 +180,7 @@ export default function Dashboard() {
           ch.update();
         }
         if (chartInstances.current.tier) {
-          setTierLegend(chartInstances.current.tier.generateLegend());
+          setTierLegend(generateLegend(chartInstances.current.tier));
         }
       }
     }

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect } from 'react';
 import { Chart } from 'chart.js/auto';
 import gradientWipe from '../plugins/gradientWipe';
+import { getCssVar } from '../utils/cssVar';
 
 export default function Sparkline({ data }: { data: number[] }) {
   const ref = useRef<HTMLCanvasElement>(null);
@@ -11,9 +12,10 @@ export default function Sparkline({ data }: { data: number[] }) {
     const labels = data.map((_, i) => i.toString());
     if (!chartRef.current) {
       Chart.register(gradientWipe);
+      const color = getCssVar('--cobalt-500', ref.current);
       chartRef.current = new Chart(ref.current, {
         type: 'line',
-        data: { labels, datasets: [{ data, borderColor: 'var(--cobalt-500)', borderWidth: 4, pointRadius: 0 }] },
+        data: { labels, datasets: [{ data, borderColor: color, borderWidth: 4, pointRadius: 0 }] },
         options: {
           responsive: true,
           maintainAspectRatio: false,

--- a/frontend/src/plugins/gradientWipe.ts
+++ b/frontend/src/plugins/gradientWipe.ts
@@ -1,4 +1,5 @@
 import { Chart } from 'chart.js/auto';
+import { getCssVar } from '../utils/cssVar';
 
 const gradientWipe = {
   id: 'gradientWipe',
@@ -16,8 +17,9 @@ const gradientWipe = {
     const x = chartArea.left + width * offset - gradWidth / 2;
 
     const gradient = ctx.createLinearGradient(x, 0, x + gradWidth, 0);
+    const color = getCssVar('--cobalt-500', chart.canvas);
     gradient.addColorStop(0, 'transparent');
-    gradient.addColorStop(0.5, 'var(--cobalt-500)');
+    gradient.addColorStop(0.5, color);
     gradient.addColorStop(1, 'transparent');
 
     ctx.save();
@@ -27,7 +29,7 @@ const gradientWipe = {
 
     if (flash > 0) {
       ctx.globalAlpha = flash;
-      ctx.fillStyle = 'var(--cobalt-500)';
+      ctx.fillStyle = color;
       ctx.fillRect(chartArea.left, chartArea.top, width, height);
       ctx.globalAlpha = 1;
     }

--- a/frontend/src/utils/chartLegend.ts
+++ b/frontend/src/utils/chartLegend.ts
@@ -1,0 +1,11 @@
+export function generateLegend(chart: import('chart.js').Chart): string {
+  const { datasets } = chart.data;
+  const items = datasets.map((ds: any) => {
+    const color = ds.borderColor || ds.backgroundColor || '#000';
+    const label = ds.label || '';
+    return `<span style="display:inline-flex;align-items:center;margin-right:8px;">
+      <span style="background-color:${color};width:10px;height:10px;display:inline-block;margin-right:4px;"></span>${label}
+    </span>`;
+  });
+  return items.join('');
+}

--- a/frontend/src/utils/cssVar.ts
+++ b/frontend/src/utils/cssVar.ts
@@ -1,0 +1,5 @@
+export function getCssVar(name: string, element: HTMLElement = document.documentElement): string {
+  const value = getComputedStyle(element).getPropertyValue(name);
+  return value.trim();
+}
+


### PR DESCRIPTION
## Summary
- add a small utility to create chart legends
- use new legend generator in Dashboard instead of removed Chart.js method
- allow Chart.js plugins and datasets to read CSS variables correctly

## Testing
- `npm test` *(fails: `jest: not found`)*
- `pytest -q` *(fails: `pytest: command not found`)*
