### PR TITLE
Update KPI chip sparkline

### DIFF
--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -13,7 +13,7 @@ export default function KPIChip({ label, value, sparkData }: Props) {
         <div className="text-sm font-medium leading-[1.4] text-[var(--color-neutral-500)]">{label}</div>
         <div className="text-2xl font-semibold leading-[1.2] text-[var(--color-neutral-900)]">{value}</div>
       </div>
-      <div className="w-2/3 h-10">
+      <div className="w-2/3 h-9 overflow-hidden rounded-lg">
         <Sparkline data={sparkData} />
       </div>
     </div>

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,36 +1,72 @@
 import { useRef, useEffect } from 'react';
 import { Chart } from 'chart.js/auto';
-import gradientWipe from '../plugins/gradientWipe';
 import { getCssVar } from '../utils/cssVar';
 
 export default function Sparkline({ data }: { data: number[] }) {
   const ref = useRef<HTMLCanvasElement>(null);
   const chartRef = useRef<Chart>();
+  const prevData = useRef<number[]>([]);
 
   useEffect(() => {
     if (!ref.current) return;
     const labels = data.map((_, i) => i.toString());
+    const color = getCssVar('--accent-primary-500', ref.current) || getCssVar('--cobalt-500', ref.current);
+
+    const ctx = ref.current.getContext('2d');
+    if (!ctx) return;
+    const hex = color.replace('#', '');
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+    const gradient = ctx.createLinearGradient(0, 0, 0, ref.current.height);
+    gradient.addColorStop(0, `rgba(${r},${g},${b},0.18)`);
+    gradient.addColorStop(1, `rgba(${r},${g},${b},0)`);
+
     if (!chartRef.current) {
-      Chart.register(gradientWipe);
-      const color = getCssVar('--cobalt-500', ref.current);
       chartRef.current = new Chart(ref.current, {
         type: 'line',
-        data: { labels, datasets: [{ data, borderColor: color, borderWidth: 4, pointRadius: 0 }] },
+        data: {
+          labels,
+          datasets: [
+            {
+              data,
+              borderColor: color,
+              backgroundColor: gradient,
+              borderWidth: 4,
+              tension: 0.4,
+              pointRadius: 0,
+              fill: 'origin',
+              capBezierPoints: true,
+            },
+          ],
+        },
         options: {
           responsive: true,
           maintainAspectRatio: false,
+          layout: { padding: { top: 6, bottom: 6, left: 0, right: 0 } },
           scales: { x: { display: false }, y: { display: false } },
           plugins: { legend: { display: false }, tooltip: { enabled: false } },
+          events: [],
+          animation: { duration: 300, easing: 'easeOutQuad' },
         },
-        plugins: [gradientWipe],
       });
-    } else {
+      prevData.current = [...data];
+    } else if (chartRef.current && !arraysEqual(prevData.current, data)) {
       const c = chartRef.current;
       c.data.labels = labels;
       (c.data.datasets[0].data as number[]) = data;
+      (c.data.datasets[0].backgroundColor as any) = gradient;
+      c.options!.animation = { duration: 200, easing: 'easeInOutQuad' } as any;
       c.update();
+      prevData.current = [...data];
     }
   }, [data]);
 
-  return <canvas ref={ref} className="w-full h-8 sparkline-gradient" />;
+  function arraysEqual(a: number[], b: number[]) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+  }
+
+  return <canvas ref={ref} className="w-full h-9" />;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,25 +10,3 @@
 body { background-color: var(--Pearl); font-family: 'Roboto Mono', monospace; color: var(--squid-ink); }
 h1,h2,h3,h4,h5,h6 { font-family: 'Inter', sans-serif; }
 
-.sparkline-gradient {
-  --wipe-offset: 0;
-  --flash-opacity: 0;
-  opacity: 0;
-  transition: opacity var(--transition-normal);
-  animation: none;
-}
-
-.kpi-chip:hover .sparkline-gradient {
-  animation: flash 0.4s ease-out, wipe 4s linear infinite 0.4s;
-  opacity: 1;
-}
-
-@keyframes wipe {
-  0% { --wipe-offset: 0; }
-  100% { --wipe-offset: 1; }
-}
-
-@keyframes flash {
-  0% { --flash-opacity: 0.6; }
-  100% { --flash-opacity: 0; }
-}

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -436,12 +436,3 @@ input[type=number] {
   }
 }
 
-.sparkline-gradient {
-  --wipe-offset: 0;
-  animation: wipe 4s linear infinite;
-}
-
-@keyframes wipe {
-  0% { --wipe-offset: 0; }
-  100% { --wipe-offset: 1; }
-}


### PR DESCRIPTION
## Summary
- make KPI chip sparkline always visible
- render sparkline with gradient fill and proper layout
- remove old sparkline animation styles

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*