### PR TITLE
Implement redesigned KPI chip

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -18,7 +18,6 @@ import KPIChip from './components/KPIChip';
 import SidePanel from './components/SidePanel';
 import InputRow from './components/InputRow';
 import ChartCard from './components/ChartCard';
-import { formatCurrency, formatNumberShort } from './utils/format';
 import { generateLegend } from './utils/chartLegend';
 
 interface FormState {
@@ -197,29 +196,34 @@ export default function Dashboard() {
       {metrics && (
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
           <KPIChip
-            label="Total MRR"
-            value={formatCurrency(metrics.total_mrr, 0)}
-            sparkData={projections.mrr}
+            labelTop="Total"
+            labelBottom="MRR"
+            value={metrics.total_mrr}
+            dataArray={projections.mrr}
           />
           <KPIChip
-            label="Active Customers"
-            value={formatNumberShort(metrics.active_customers)}
-            sparkData={projections.customers}
+            labelTop="Active"
+            labelBottom="Customers"
+            value={metrics.active_customers}
+            dataArray={projections.customers}
           />
           <KPIChip
-            label="Annual Revenue"
-            value={formatCurrency(metrics.annual_revenue, 1)}
-            sparkData={projections.mrr.map((v) => v * 12)}
+            labelTop="Annual"
+            labelBottom="Revenue"
+            value={metrics.annual_revenue}
+            dataArray={projections.mrr.map((v) => v * 12)}
           />
           <KPIChip
-            label="Customer LTV"
-            value={formatCurrency(metrics.ltv, 1)}
-            sparkData={projections.mrr.map((v) => v / (form.churn_rate_smb / 100))}
+            labelTop="Customer"
+            labelBottom="LTV"
+            value={metrics.ltv}
+            dataArray={projections.mrr.map((v) => v / (form.churn_rate_smb / 100))}
           />
           <KPIChip
-            label="Total Customers"
-            value={formatNumberShort(metrics.total_customers)}
-            sparkData={projections.customers}
+            labelTop="Total"
+            labelBottom="Customers"
+            value={metrics.total_customers}
+            dataArray={projections.customers}
           />
         </div>
       )}

--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -1,21 +1,64 @@
+import { useEffect, useRef, useState } from 'react';
 import Sparkline from './Sparkline';
+import { formatNumberShort } from '../utils/format';
 
 interface Props {
-  label: string;
-  value: string | number;
-  sparkData: number[];
+  labelTop: string;
+  labelBottom?: string;
+  value: number | string;
+  dataArray: number[];
 }
 
-export default function KPIChip({ label, value, sparkData }: Props) {
+export default function KPIChip({ labelTop, labelBottom, value, dataArray }: Props) {
+  const [refreshing, setRefreshing] = useState(true);
+  const prevData = useRef<number[]>([]);
+
+  useEffect(() => {
+    if (!arraysEqual(prevData.current, dataArray)) {
+      setRefreshing(true);
+      prevData.current = [...dataArray];
+    }
+  }, [dataArray]);
+
+  const handleRendered = () => {
+    setTimeout(() => setRefreshing(false), 400);
+  };
+
+  const displayValue =
+    typeof value === 'number' ? formatNumberShort(value) : value;
+
   return (
-    <div className="kpi-chip bg-[var(--color-neutral-50)] border border-[var(--color-neutral-200)] rounded-lg px-4 py-3 flex items-center">
-      <div className="w-1/3 text-left">
-        <div className="text-sm font-medium leading-[1.4] text-[var(--color-neutral-500)]">{label}</div>
-        <div className="text-2xl font-semibold leading-[1.2] text-[var(--color-neutral-900)]">{value}</div>
+    <div
+      className={`relative border border-[var(--neutral-200)] rounded-lg bg-[var(--neutral-50)] p-4 h-[80px] md:h-[100px] transition-opacity duration-500 ${
+        refreshing ? 'opacity-40' : 'opacity-100'
+      }`}
+    >
+      <div className="h-full md:grid md:grid-cols-5 flex flex-col" >
+        <div className="md:col-span-2 flex flex-col text-left">
+          <div className="font-sans font-medium text-[11px] md:text-[12px] text-[var(--neutral-400)] leading-none">
+            {labelTop}
+          </div>
+          {labelBottom && (
+            <div className="font-sans font-semibold text-[11px] md:text-[12px] text-[var(--neutral-600)] leading-none">
+              {labelBottom}
+            </div>
+          )}
+        </div>
+        <div className="md:col-span-3 flex items-center md:justify-end justify-center font-sans font-bold text-[24px] md:text-[32px] text-[var(--neutral-900)] relative z-2">
+          {displayValue}
+        </div>
       </div>
-      <div className="w-2/3 h-9 overflow-hidden rounded-lg">
-        <Sparkline data={sparkData} />
-      </div>
+      <Sparkline
+        data={dataArray}
+        onRendered={handleRendered}
+        className="absolute left-[4px] right-[4px] bottom-0"
+      />
     </div>
   );
+
+  function arraysEqual(a: number[], b: number[]) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+  }
 }


### PR DESCRIPTION
## Summary
- update `Sparkline` to allow callbacks and styling adjustments
- add redesigned `KPIChip` component following new spec
- use new KPIChip in the dashboard

## Testing
- `npm test` *(fails: jest not installed)*
- `pytest -q` *(fails: command not found)*