### PR TITLE
Fix KPI chip formatting issues

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -239,7 +239,7 @@ export default function Dashboard() {
               <InlineNumberInput
                 key={n}
                 label={`Tier ${n}`}
-                unit="$"
+                unit="currency"
                 value={form[`tier${n}_revenue` as keyof FormState] as number}
                 onChange={(v) => handleValueChange(`tier${n}_revenue` as keyof FormState, v)}
               />
@@ -247,17 +247,17 @@ export default function Dashboard() {
           </div>
           <div className="space-y-3 mb-6">
             <h3 className="text-sm font-semibold mb-2 font-sans">Marketing</h3>
-            <InlineNumberInput label="Budget" unit="$" value={form.marketing_budget} onChange={(v) => handleValueChange('marketing_budget', v)} />
-            <InlineNumberInput label="CPL" unit="$" value={form.cpl} onChange={(v) => handleValueChange('cpl', v)} />
-            <InlineNumberInput label="CVR" unit="%" value={form.conversion_rate} onChange={(v) => handleValueChange('conversion_rate', v)} />
+            <InlineNumberInput label="Budget" unit="currency" value={form.marketing_budget} onChange={(v) => handleValueChange('marketing_budget', v)} />
+            <InlineNumberInput label="CPL" unit="currency" value={form.cpl} onChange={(v) => handleValueChange('cpl', v)} />
+            <InlineNumberInput label="CVR" unit="percent" value={form.conversion_rate} onChange={(v) => handleValueChange('conversion_rate', v)} />
           </div>
           <div className="space-y-3">
             <h3 className="text-sm font-semibold mb-2 font-sans">Financial</h3>
-            <InlineNumberInput label="Churn %" unit="%" value={form.churn_rate_smb} onChange={(v) => handleValueChange('churn_rate_smb', v)} />
-            <InlineNumberInput label="WACC %" unit="%" value={form.wacc} onChange={(v) => handleValueChange('wacc', v)} />
+            <InlineNumberInput label="Churn %" unit="percent" value={form.churn_rate_smb} onChange={(v) => handleValueChange('churn_rate_smb', v)} />
+            <InlineNumberInput label="WACC %" unit="percent" value={form.wacc} onChange={(v) => handleValueChange('wacc', v)} />
             <InlineNumberInput label="Months" value={form.projection_months} onChange={(v) => handleValueChange('projection_months', v)} />
-            <InlineNumberInput label="Opex %" unit="%" value={form.operating_expense_rate} onChange={(v) => handleValueChange('operating_expense_rate', v)} />
-            <InlineNumberInput label="Fixed Costs" unit="$" value={form.fixed_costs} onChange={(v) => handleValueChange('fixed_costs', v)} />
+            <InlineNumberInput label="Opex %" unit="percent" value={form.operating_expense_rate} onChange={(v) => handleValueChange('operating_expense_rate', v)} />
+            <InlineNumberInput label="Fixed Costs" unit="currency" value={form.fixed_costs} onChange={(v) => handleValueChange('fixed_costs', v)} />
           </div>
         </SidePanel>
         <div className="flex-1 space-y-4">

--- a/frontend/src/components/InlineNumberInput.tsx
+++ b/frontend/src/components/InlineNumberInput.tsx
@@ -4,7 +4,7 @@ import { formatCurrency, formatNumberShort } from '../utils/format';
 interface Props {
   label: string;
   value: number;
-  unit?: '$' | '%';
+  unit?: 'currency' | 'percent';
   onChange: (value: number) => void;
 }
 
@@ -13,8 +13,8 @@ export default function InlineNumberInput({ label, value, unit, onChange }: Prop
   const [temp, setTemp] = useState<number>(value);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const display = unit === '$' ? formatCurrency(value) :
-                  unit === '%' ? `${value}%` : formatNumberShort(value);
+  const display = unit === 'currency' ? formatCurrency(value) :
+                  unit === 'percent' ? value.toString() : formatNumberShort(value);
 
   const handleFocus = () => {
     setEditing(true);

--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
 import Sparkline from './Sparkline';
-import { formatNumberShort } from '../utils/format';
+import { formatNumberShort, formatCurrency } from '../utils/format';
 
 interface Props {
   labelTop: string;
   labelBottom?: string;
   value: number | string;
   dataArray: number[];
+  unit?: 'currency' | 'percent';
 }
 
-export default function KPIChip({ labelTop, labelBottom, value, dataArray }: Props) {
+export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit }: Props) {
   const [refreshing, setRefreshing] = useState(true);
   const prevData = useRef<number[]>([]);
 
@@ -25,12 +26,16 @@ export default function KPIChip({ labelTop, labelBottom, value, dataArray }: Pro
   };
 
   const displayValue =
-    typeof value === 'number' ? formatNumberShort(value) : value;
+    typeof value === 'number'
+      ? unit === 'currency'
+        ? formatCurrency(value)
+        : formatNumberShort(value)
+      : value;
 
   return (
     <div
-      className={`relative border border-[var(--neutral-200)] rounded-lg bg-[var(--neutral-50)] p-4 h-[80px] md:h-[100px] transition-opacity duration-500 ${
-        refreshing ? 'opacity-40' : 'opacity-100'
+      className={`relative border border-[var(--neutral-200)] rounded-lg bg-[var(--neutral-50)] p-4 h-[80px] md:h-[100px] overflow-hidden ${
+        refreshing ? 'refreshing' : ''
       }`}
     >
       <div className="h-full md:grid md:grid-cols-5 flex flex-col" >
@@ -45,13 +50,13 @@ export default function KPIChip({ labelTop, labelBottom, value, dataArray }: Pro
           )}
         </div>
         <div className="md:col-span-3 flex items-center md:justify-end justify-center font-sans font-bold text-[24px] md:text-[32px] text-[var(--neutral-900)] relative z-2">
-          {displayValue}
+          <span className="metric-value" data-unit={unit}>{displayValue}</span>
         </div>
       </div>
       <Sparkline
         data={dataArray}
         onRendered={handleRendered}
-        className="absolute left-[4px] right-[4px] bottom-0"
+        className="spark left-[4px] right-[4px]"
       />
     </div>
   );

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -44,7 +44,7 @@ export default function Sparkline({ data, className = '', onRendered }: Props) {
               data,
               borderColor: color,
               backgroundColor: gradient,
-              borderWidth: 4,
+              borderWidth: 3,
               tension: 0.4,
               pointRadius: 0,
               fill: 'origin',
@@ -55,7 +55,7 @@ export default function Sparkline({ data, className = '', onRendered }: Props) {
         options: {
           responsive: true,
           maintainAspectRatio: false,
-          layout: { padding: { top: 6, bottom: 6, left: 0, right: 0 } },
+          layout: { padding: { top: 12, bottom: 6, left: 0, right: 0 } },
           scales: { x: { display: false }, y: { display: false } },
           plugins: { legend: { display: false }, tooltip: { enabled: false } },
           events: [],
@@ -85,8 +85,7 @@ export default function Sparkline({ data, className = '', onRendered }: Props) {
   return (
     <canvas
       ref={ref}
-      className={`w-full pointer-events-none ${className}`}
-      style={{ height: '28px', clipPath: 'inset(0 round 8px)' }}
+      className={`w-full ${className}`}
     />
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,6 @@
+@tailwind base;
 @import "./styles/brand-tokens.css";
 @import "./styles/design-system.css";
-@tailwind base;
 @tailwind components;
 @tailwind utilities;
 

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -9,10 +9,19 @@ h1,h2,h3,h4,h5,h6{font-family:'Inter',sans-serif;}
 input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
              padding:.5rem 1rem;background:#fff;}
 
+/* simple color swatch */
+.swatch{display:inline-block;width:16px;height:16px;border-radius:4px;margin-right:8px;}
+
+/* sparkline canvas */
+.spark{position:absolute;inset:0 0 8px 0;z-index:1;height:28px;pointer-events:none;clip-path:inset(0 round 8px);}
+
+.refreshing{opacity:0.4;transition:opacity .3s;}
+
 /* metric cards */
 .metric-card{border:1px solid var(--cat-driftwood);border-radius:12px;
-             padding:1rem;display:flex;flex-direction:column;gap:.5rem;}
-.metric-value{font-size:1.75rem;font-weight:500;line-height:110%;letter-spacing:-0.04em;transition:color .3s;font-family:'Inter',sans-serif;}
+             padding:1rem;display:flex;flex-direction:column;gap:.5rem;
+             overflow:hidden;}
+.metric-value{font-size:1.75rem;font-weight:500;line-height:110%;letter-spacing:-0.04em;transition:color .3s;font-family:'Inter',sans-serif;position:relative;z-index:2;}
 .metric-label{font-size:0.875rem;color:var(--neutral-400);font-family:'Roboto Mono',monospace;}
 
 /* interactive card */
@@ -143,16 +152,17 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
   font-weight:700;
   position:relative;
 }
-.chip .value[data-unit="$"]{padding-left:0.65rem;}
-.chip .value[data-unit="$"]::after{
+.chip .value[data-unit="currency"]{padding-left:0.65rem;}
+.chip .value[data-unit="currency"]::before{
   content:"$";
   position:absolute;
   left:0;
 }
-.chip .value[data-unit="%"]::after{
+.chip .value[data-unit="percent"]::after{
   content:"%";
   margin-left:0.15rem;
 }
+.chip.editing .value::before,
 .chip.editing .value::after{content:"";}
 .chip input{
   position:absolute;

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -1,19 +1,19 @@
 import { formatCurrency, formatPercentage, formatNumberShort } from './format';
 
 test('format currency millions', () => {
-  expect(formatCurrency(1270000)).toBe('$1.27M');
+  expect(formatCurrency(1270000)).toBe('1.27M');
 });
 
 test('format currency thousands', () => {
-  expect(formatCurrency(7900)).toBe('$7.9K');
+  expect(formatCurrency(7900)).toBe('7.9K');
 });
 
 test('format currency small', () => {
-  expect(formatCurrency(500)).toBe('$500');
+  expect(formatCurrency(500)).toBe('500');
 });
 
 test('custom decimals', () => {
-  expect(formatCurrency(1500000, 0)).toBe('$2M');
+  expect(formatCurrency(1500000, 0)).toBe('2M');
 });
 
 test('percentage tolerance', () => {

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,18 +1,23 @@
-export function formatNumberShort(value: number, decimals?: number): string {
-  if (value >= 1_000_000) {
-    const d = decimals ?? 2;
-    return `${(value / 1_000_000).toFixed(d)}M`;
-  } else if (value >= 1_000) {
-    const d = decimals ?? 1;
-    return `${(value / 1_000).toFixed(d)}K`;
+export function formatNumberShort(value: number, decimals = 0): string {
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) {
+    const d = decimals || 2;
+    const num = (value / 1_000_000).toFixed(d);
+    return parseFloat(num).toString() + 'M';
+  } else if (abs >= 1_000) {
+    const num = (value / 1_000)
+      .toPrecision(2)
+      .replace(/\.0$/, '');
+    return num + 'K';
   }
-  return value.toLocaleString();
+  return value.toLocaleString(undefined, { maximumFractionDigits: decimals });
 }
 
 export function formatCurrency(value: number, decimals?: number): string {
-  return '$' + formatNumberShort(value, decimals);
+  return formatNumberShort(value, decimals);
 }
 
 export function formatPercentage(value: number): string {
-  return `${(value * 100).toFixed(1)}%`;
+  const pct = (value * 100).toFixed(1).replace(/\.0$/, '');
+  return pct;
 }


### PR DESCRIPTION
## Summary
- improve style ordering and add sparkline/chip styles
- update number formatting helpers
- adapt KPIChip and InlineNumberInput to new units
- tweak sparkline rendering
- fix related unit tests

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*