### PR TITLE
Fix stray slash in input component

### DIFF
--- a/frontend/src/components/InlineNumberInput.tsx
+++ b/frontend/src/components/InlineNumberInput.tsx
@@ -39,7 +39,7 @@ export default function InlineNumberInput({ label, value, unit, onChange, name, 
   };
 
   return (
-    <div className={`chip ${editing ? 'editing' : ''}`}>\
+    <div className={`chip ${editing ? 'editing' : ''}`}>
       <span className="label">{label}</span>
       <span className="value" data-unit={unit}>{display}</span>
       <input


### PR DESCRIPTION
## Summary
- fix accidental backslash in `InlineNumberInput` that rendered a `/` before each field

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `npm test --silent` in `frontend` *(fails: jest not found)*