### PR TITLE
Fix KPI chip layout issues

### DIFF
--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -32,31 +32,23 @@ export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit 
         : formatNumberShort(value)
       : value;
 
+  const sparkData = [...dataArray].reverse();
+
   return (
     <div
-      className={`relative border border-[var(--neutral-200)] rounded-lg bg-[var(--neutral-50)] p-4 h-[80px] md:h-[100px] overflow-hidden ${
-        refreshing ? 'refreshing' : ''
-      }`}
+      className={`kpi-card ${refreshing ? 'refreshing' : ''}`}
     >
-      <div className="h-full md:grid md:grid-cols-5 flex flex-col" >
-        <div className="md:col-span-2 flex flex-col text-left">
-          <div className="font-sans font-medium text-[11px] md:text-[12px] text-[var(--neutral-400)] leading-none">
-            {labelTop}
-          </div>
-          {labelBottom && (
-            <div className="font-sans font-semibold text-[11px] md:text-[12px] text-[var(--neutral-600)] leading-none">
-              {labelBottom}
-            </div>
-          )}
-        </div>
-        <div className="md:col-span-3 flex items-center md:justify-end justify-center font-sans font-bold text-[24px] md:text-[32px] text-[var(--neutral-900)] relative z-2">
-          <span className="metric-value" data-unit={unit}>{displayValue}</span>
-        </div>
+      <div className="label-block">
+        <div className="leading-none">{labelTop}</div>
+        {labelBottom && <div className="leading-none">{labelBottom}</div>}
+      </div>
+      <div className="metric mt-1">
+        <span className="metric-value" data-unit={unit}>{displayValue}</span>
       </div>
       <Sparkline
-        data={dataArray}
+        data={sparkData}
         onRendered={handleRendered}
-        className="spark left-[4px] right-[4px]"
+        className="sparkline left-[4px] right-[4px]"
       />
     </div>
   );

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -13,7 +13,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .swatch{display:inline-block;width:16px;height:16px;border-radius:4px;margin-right:8px;}
 
 /* sparkline canvas */
-.spark{position:absolute;inset:0 0 8px 0;z-index:1;height:28px;pointer-events:none;clip-path:inset(0 round 8px);}
+.sparkline{position:absolute;inset:0 0 8px 0;height:28px;bottom:0;z-index:1;pointer-events:none;clip-path:inset(0 round 8px);}
 
 .refreshing{opacity:0.4;transition:opacity .3s;}
 
@@ -23,6 +23,11 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
              overflow:hidden;}
 .metric-value{font-size:1.75rem;font-weight:500;line-height:110%;letter-spacing:-0.04em;transition:color .3s;font-family:'Inter',sans-serif;position:relative;z-index:2;}
 .metric-label{font-size:0.875rem;color:var(--neutral-400);font-family:'Roboto Mono',monospace;}
+
+/* KPI chips */
+.kpi-card{position:relative;background:var(--neutral-50);border:1px solid var(--neutral-200);border-radius:8px;padding:1rem;overflow:hidden;}
+.kpi-card .label-block div{font-size:0.6875rem;font-weight:500;color:var(--neutral-600);font-family:'Inter',sans-serif;}
+.kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
 
 /* interactive card */
 .interactive-card>.card-header{all:unset;display:flex;justify-content:space-between;

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -16,6 +16,10 @@ test('custom decimals', () => {
   expect(formatCurrency(1500000, 0)).toBe('2M');
 });
 
+test('clamps to 3 digits', () => {
+  expect(formatNumberShort(550000)).toBe('550K');
+});
+
 test('percentage tolerance', () => {
   const val = 0.1234;
   const pct = parseFloat(formatPercentage(val));

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,14 +1,18 @@
 export function formatNumberShort(value: number, decimals = 0): string {
   const abs = Math.abs(value);
   if (abs >= 1_000_000) {
-    const d = decimals || 2;
-    const num = (value / 1_000_000).toFixed(d);
-    return parseFloat(num).toString() + 'M';
-  } else if (abs >= 1_000) {
-    const num = (value / 1_000)
-      .toPrecision(2)
-      .replace(/\.0$/, '');
-    return num + 'K';
+    return (
+      (value / 1_000_000)
+        .toFixed(2)
+        .replace(/\.0+$/, '') + 'M'
+    );
+  }
+  if (abs >= 1_000) {
+    return (
+      (value / 1_000)
+        .toFixed(1)
+        .replace(/\.0$/, '') + 'K'
+    );
   }
   return value.toLocaleString(undefined, { maximumFractionDigits: decimals });
 }

--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -14,6 +14,12 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .metric-value{font-size:1.25rem;font-weight:700;transition:color .3s;}
 .metric-label{font-size:0.875rem; color: #4c5d70; /* Neutral-700 like */}
 
+/* KPI chips */
+.kpi-card{position:relative;background:var(--neutral-50);border:1px solid var(--neutral-200);border-radius:8px;padding:1rem;overflow:hidden;}
+.kpi-card .label-block div{font-size:0.6875rem;font-weight:500;color:var(--neutral-600);font-family:'Inter',sans-serif;}
+.kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
+.sparkline{position:absolute;inset:0 0 8px 0;height:28px;bottom:0;z-index:1;pointer-events:none;clip-path:inset(0 round 8px);}
+
 /* interactive card */
 .interactive-card>.card-header{all:unset;display:flex;justify-content:space-between;
                                cursor:pointer;padding:1rem;align-items:center;}


### PR DESCRIPTION
## Summary
- adjust number formatting helper
- update KPI chip markup and sparkline data
- tweak CSS styles for KPI chips
- add test coverage for new formatter logic

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: command not found)*