### PR TITLE
Refine KPI chip layout

### DIFF
--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -48,7 +48,7 @@ export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit 
       <Sparkline
         data={sparkData}
         onRendered={handleRendered}
-        className="sparkline left-[4px] right-[4px]"
+        className="sparkline mt-1"
       />
     </div>
   );

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -61,7 +61,7 @@ export default function Sparkline({ data, className = '', onRendered }: Props) {
               data,
               borderColor: color,
               backgroundColor: gradient,
-              borderWidth: 3,
+              borderWidth: 2,
               tension: 0.4,
               pointRadius: 0,
               fill: 'origin',

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -13,7 +13,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .swatch{display:inline-block;width:16px;height:16px;border-radius:4px;margin-right:8px;}
 
 /* sparkline canvas */
-.sparkline{position:absolute;inset:0 0 8px 0;height:28px;bottom:0;z-index:1;pointer-events:none;clip-path:inset(0 round 8px);}
+.sparkline{display:block;width:100%;height:32px;pointer-events:none;clip-path:inset(0 round 8px);}
 
 .refreshing{opacity:0.4;transition:opacity .3s;}
 
@@ -25,8 +25,8 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .metric-label{font-size:0.875rem;color:var(--neutral-400);font-family:'Roboto Mono',monospace;}
 
 /* KPI chips */
-.kpi-card{position:relative;background:var(--neutral-50);border:1px solid var(--neutral-200);border-radius:8px;padding:1rem;overflow:hidden;}
-.kpi-card .label-block div{font-size:0.6875rem;font-weight:500;color:var(--neutral-600);font-family:'Inter',sans-serif;}
+.kpi-card{position:relative;background:var(--neutral-50);border:1px solid var(--neutral-200);border-radius:8px;padding:1rem;overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;}
+.kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-neutral-500);font-family:'Roboto Mono',monospace;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
 
 /* interactive card */

--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -15,10 +15,10 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .metric-label{font-size:0.875rem; color: #4c5d70; /* Neutral-700 like */}
 
 /* KPI chips */
-.kpi-card{position:relative;background:var(--neutral-50);border:1px solid var(--neutral-200);border-radius:8px;padding:1rem;overflow:hidden;}
-.kpi-card .label-block div{font-size:0.6875rem;font-weight:500;color:var(--neutral-600);font-family:'Inter',sans-serif;}
+.kpi-card{position:relative;background:var(--neutral-50);border:1px solid var(--neutral-200);border-radius:8px;padding:1rem;overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;}
+.kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-neutral-500);font-family:'Roboto Mono',monospace;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
-.sparkline{position:absolute;inset:0 0 8px 0;height:28px;bottom:0;z-index:1;pointer-events:none;clip-path:inset(0 round 8px);}
+.sparkline{display:block;width:100%;height:32px;pointer-events:none;clip-path:inset(0 round 8px);}
 
 /* interactive card */
 .interactive-card>.card-header{all:unset;display:flex;justify-content:space-between;


### PR DESCRIPTION
## Summary
- stack KPI chip sparkline below the label and value
- narrow sparkline stroke
- use Roboto Mono for KPI labels with neutral-500 color

## Testing
- `npm test --silent` *(fails: `jest: not found`)*