### PR TITLE
Fix KPI bar layout stability

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -183,7 +183,16 @@ export default function Dashboard() {
         }
       }
     }
-    return () => {};
+    return () => {
+      if (chartInstances.current.combined) {
+        chartInstances.current.combined.destroy();
+        delete chartInstances.current.combined;
+      }
+      if (chartInstances.current.tier) {
+        chartInstances.current.tier.destroy();
+        delete chartInstances.current.tier;
+      }
+    };
   }, [form]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/components/ChartCard.tsx
+++ b/frontend/src/components/ChartCard.tsx
@@ -21,7 +21,7 @@ export default function ChartCard({ title, children, legend }: Props) {
           </div>
         )}
       </div>
-      <Card className="relative">
+      <Card className="relative overflow-hidden">
         <div className="h-64 relative">{children}</div>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- prevent charts from growing their container by hiding overflow
- clean up Chart.js instances on Dashboard effect cleanup

## Testing
- `npm test` *(fails: `jest: not found`)*