### PR TITLE
Fix sparkline height to stop KPI cards from expanding

### DIFF
--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -13,7 +13,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .swatch{display:inline-block;width:16px;height:16px;border-radius:4px;margin-right:8px;}
 
 /* sparkline canvas */
-.sparkline{display:block;width:100%;height:32px;pointer-events:none;clip-path:inset(0 round 8px);}
+.sparkline{display:block;width:100%;height:32px!important;pointer-events:none;clip-path:inset(0 round 8px);}
 
 .refreshing{opacity:0.4;transition:opacity .3s;}
 

--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -19,7 +19,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-neutral-500);font-family:'Roboto Mono',monospace;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
 .kpi-card .top-row{display:flex;justify-content:space-between;align-items:flex-end;}
-.sparkline{display:block;width:100%;height:32px;pointer-events:none;clip-path:inset(0 round 8px);}
+.sparkline{display:block;width:100%;height:32px!important;pointer-events:none;clip-path:inset(0 round 8px);}
 
 /* interactive card */
 .interactive-card>.card-header{all:unset;display:flex;justify-content:space-between;


### PR DESCRIPTION
## Summary
- keep sparkline chart height fixed with `!important`

## Testing
- `npm test` *(fails: jest not found)*