### PR TITLE
Fix duplicate KPI row styles

### DIFF
--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -13,7 +13,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .swatch{display:inline-block;width:16px;height:16px;border-radius:4px;margin-right:8px;}
 
 /* sparkline canvas */
-.sparkline{display:block;width:100%;height:32px;pointer-events:none;clip-path:inset(0 round 8px);}
+.sparkline{display:block;width:100%;height:32px!important;pointer-events:none;clip-path:inset(0 round 8px);}
 
 .refreshing{opacity:0.4;transition:opacity .3s;}
 
@@ -44,13 +44,13 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 /* #kpiRow styling is now primarily for flex behavior on small screens */
 #kpiRow{
     display:flex; /* Horizontal layout on small screens */
-    gap:1rem; /* Spacing between KPI cards */
+    gap:var(--space-md); /* Spacing between KPI cards */
     overflow-x:auto; /* Enable horizontal scrolling */
-    padding-bottom: 1rem; /* Space for scrollbar if it appears */
+    padding-bottom:var(--space-sm); /* Space for scrollbar if it appears */
     /* Prevent flex items from shrinking too much */
-    & > .metric-card { 
+    & > .metric-card {
         flex: 0 0 auto; /* Don't grow, don't shrink, auto basis */
-        width: 200px; /* Example fixed width for scrollable items, adjust as needed */
+        width: 220px; /* Fixed width for scrollable items */
     }
 }
 @media(min-width:1024px){ /* lg breakpoint */
@@ -96,14 +96,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .max-h-\[calc\(100vh-140px\)\] { max-height: calc(100vh - 140px); } /* From HTML shell */
 .overflow-y-auto { overflow-y: auto; } /* From HTML shell */
 
-/* KPI horizontal scroll on narrow screens */
-#kpiRow{
-  display:flex;
-  gap:var(--space-md);
-  overflow-x:auto;
-  padding-bottom:var(--space-sm);
-}
-#kpiRow .metric-card{flex:0 0 220px;}
+
 
 /* Typography helpers */
 .main-header{

--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -19,7 +19,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-neutral-500);font-family:'Roboto Mono',monospace;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
 .kpi-card .top-row{display:flex;justify-content:space-between;align-items:flex-end;}
-.sparkline{display:block;width:100%;height:32px;pointer-events:none;clip-path:inset(0 round 8px);}
+.sparkline{display:block;width:100%;height:32px!important;pointer-events:none;clip-path:inset(0 round 8px);}
 
 /* interactive card */
 .interactive-card>.card-header{all:unset;display:flex;justify-content:space-between;
@@ -35,13 +35,13 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 /* #kpiRow styling is now primarily for flex behavior on small screens */
 #kpiRow{
     display:flex; /* Horizontal layout on small screens */
-    gap:1rem; /* Spacing between KPI cards */
+    gap:var(--space-md); /* Spacing between KPI cards */
     overflow-x:auto; /* Enable horizontal scrolling */
-    padding-bottom: 1rem; /* Space for scrollbar if it appears */
+    padding-bottom:var(--space-sm); /* Space for scrollbar if it appears */
     /* Prevent flex items from shrinking too much */
-    & > .metric-card { 
+    & > .metric-card {
         flex: 0 0 auto; /* Don't grow, don't shrink, auto basis */
-        width: 200px; /* Example fixed width for scrollable items, adjust as needed */
+        width: 220px; /* Fixed width for scrollable items */
     }
 }
 @media(min-width:1024px){ /* lg breakpoint */
@@ -87,11 +87,4 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .max-h-\[calc\(100vh-140px\)\] { max-height: calc(100vh - 140px); } /* From HTML shell */
 .overflow-y-auto { overflow-y: auto; } /* From HTML shell */
 
-/* KPI horizontal scroll on narrow screens */
-#kpiRow{
-  display:flex;
-  gap:var(--space-md);
-  overflow-x:auto;
-  padding-bottom:var(--space-sm);
-}
-#kpiRow .metric-card{flex:0 0 220px;}
+


### PR DESCRIPTION
## Summary
- unify `#kpiRow` styles across CSS files
- remove the extra conflicting block that redefined the KPI row

## Testing
- `npm test --silent` *(fails: jest not found)*