### PR TITLE
Hide display value when editing number input

### DIFF
--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -161,6 +161,9 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
   content:"%";
   margin-left:0.15rem;
 }
+.chip.editing .value{
+  visibility:hidden;
+}
 .chip.editing .value::before,
 .chip.editing .value::after{content:"";}
 .chip input{


### PR DESCRIPTION
## Summary
- hide formatted value in `.chip` when editing number inputs

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*
- `npm test` *(fails: `jest: not found`)*