### PR TITLE
Fix tier customer chart distribution

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -10,6 +10,7 @@ import {
   DEFAULT_INITIAL_INVESTMENT,
   DEFAULT_OPERATING_EXPENSE_RATE,
   DEFAULT_FIXED_COSTS,
+  DEFAULT_TIER_ADOPTION,
 } from './model/constants';
 import { runSubscriptionModel } from './model/subscription';
 import { calculateFinancialMetrics } from './model/finance';
@@ -97,6 +98,7 @@ export default function Dashboard() {
       projection_months: form.projection_months,
       operating_expense_rate: form.operating_expense_rate,
       fixed_costs: form.fixed_costs,
+      tier_adoption_rates: DEFAULT_TIER_ADOPTION,
     };
 
     const expenses = {

--- a/frontend/src/model/constants.ts
+++ b/frontend/src/model/constants.ts
@@ -9,3 +9,6 @@ export const DEFAULT_PROJECTION_MONTHS = 24;
 export const DEFAULT_INITIAL_INVESTMENT = 200000;
 export const DEFAULT_OPERATING_EXPENSE_RATE = 35;
 export const DEFAULT_FIXED_COSTS = Math.round(50000 / 12);
+// Default customer mix across pricing tiers, approximating a
+// typical distribution weighted toward lower tiers.
+export const DEFAULT_TIER_ADOPTION = [0.45, 0.3, 0.15, 0.1];


### PR DESCRIPTION
## Summary
- add DEFAULT_TIER_ADOPTION constant
- compute tier revenues using adoption mix
- pass adoption mix to dashboard model

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `npm test` *(fails: jest not found)*
