### PR TITLE
Update KPI layout and terminology

### DIFF
--- a/frontend/src/model/subscription.ts
+++ b/frontend/src/model/subscription.ts
@@ -23,10 +23,10 @@ export interface SubscriptionResult {
   };
   metrics: {
     total_mrr: number;
-    total_customers: number;
+    total_subscribers: number;
     annual_revenue: number;
-    customer_ltv: number;
-    new_customers_monthly: number;
+    subscriber_ltv: number;
+    new_subscribers_monthly: number;
   };
 }
 
@@ -86,13 +86,13 @@ export function runSubscriptionModel(input: SubscriptionInput): SubscriptionResu
     },
     metrics: {
       total_mrr: mrr_by_month[mrr_by_month.length - 1],
-      total_customers: customers_by_month[customers_by_month.length - 1],
+      total_subscribers: customers_by_month[customers_by_month.length - 1],
       annual_revenue: mrr_by_month.slice(0, 12).reduce((a, b) => a + b, 0),
-      customer_ltv:
-        ((mrr_by_month.reduce((a, b) => a + b, 0) / months) *
+      subscriber_ltv:
+        (avgRevenuePerCustomer *
           (1 - (input.operating_expense_rate ?? 0) / 100)) /
         (churn || 1),
-      new_customers_monthly:
+      new_subscribers_monthly:
         customers_by_month[1] - (input.initial_customers || 10),
     },
   };

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -25,10 +25,10 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .metric-label{font-size:0.875rem;color:var(--neutral-400);font-family:'Roboto Mono',monospace;}
 
 /* KPI chips */
-.kpi-card{position:relative;background:var(--neutral-50);border:1px solid var(--neutral-200);border-radius:8px;padding:1rem;overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;}
-.kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-neutral-500);font-family:'Roboto Mono',monospace;}
+.kpi-card{position:relative;background:var(--neutral-50);border:1px solid var(--neutral-200);border-radius:8px;padding:var(--space-sm) var(--space-md);overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;}
+.kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-neutral-500);font-family:'Roboto Mono',monospace;line-height:1;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
-.kpi-card .top-row{display:flex;justify-content:space-between;align-items:flex-end;}
+.kpi-card .top-row{display:flex;justify-content:space-between;align-items:center;}
 
 /* interactive card */
 .interactive-card>.card-header{all:unset;display:flex;justify-content:space-between;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -117,12 +117,12 @@ function calc(formData) {
       mrrArr: combinedResults.projections?.mrr_by_month || [],
       custArr: combinedResults.projections?.customers_by_month || [],
       tierArr: combinedResults.projections?.tier_revenues_end || [],
-      metrics: { 
+      metrics: {
           total_mrr: combinedResults.metrics?.total_mrr || 0,
-          active_customers: combinedResults.metrics?.total_customers || 0,
+          total_subscribers: combinedResults.metrics?.total_subscribers || 0,
           annual_revenue: combinedResults.metrics?.annual_revenue || 0,
-          ltv: combinedResults.metrics?.customer_ltv || 0, // Mapped from customer_ltv
-          new_cust_month: combinedResults.metrics?.new_customers_monthly || 0 // Mapped from new_customers_monthly
+          subscriber_ltv: combinedResults.metrics?.subscriber_ltv || 0,
+          new_sub_month: combinedResults.metrics?.new_subscribers_monthly || 0
       }
   };
 }

--- a/static/js/model/subscription.js
+++ b/static/js/model/subscription.js
@@ -36,12 +36,12 @@ export function runSubscriptionModel(input) {
     },
     metrics: {
       total_mrr: mrr_by_month[mrr_by_month.length-1],
-      total_customers: customers_by_month[customers_by_month.length-1],
+      total_subscribers: customers_by_month[customers_by_month.length-1],
       annual_revenue: mrr_by_month.slice(0,12).reduce((a,b)=>a+b,0),
-      customer_ltv:
-        ((mrr_by_month.reduce((a,b)=>a+b,0)/months) * (1 - (input.operating_expense_rate||0)/100)) /
+      subscriber_ltv:
+        (avgRevenuePerCustomer * (1 - (input.operating_expense_rate||0)/100)) /
         (churn || 1),
-      new_customers_monthly: monthlyAcquisition
+      new_subscribers_monthly: monthlyAcquisition
     }
   };
 }


### PR DESCRIPTION
## Summary
- replace customer terminology with subscriber
- compute subscriber LTV using blended revenue per tier
- show five KPI chips in a responsive grid
- adjust KPI card spacing and alignment

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q` *(fails: command not found)*