### PR TITLE
Update KPI layout and terminology

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -41,13 +41,11 @@ interface FormState {
 
 interface Metrics {
   total_mrr: number;
-  active_customers: number;
   annual_revenue: number;
-  ltv: number;
-  total_customers: number;
+  subscriber_ltv: number;
+  total_subscribers: number;
   npv: number;
   paybackMonths: number | null;
-  blended_cpl: number;
   blended_cvr: number;
 }
 
@@ -68,7 +66,7 @@ export default function Dashboard() {
   });
 
   const [metrics, setMetrics] = useState<Metrics | null>(null);
-  const [projections, setProjections] = useState<{ mrr: number[]; customers: number[] }>({ mrr: [], customers: [] });
+  const [projections, setProjections] = useState<{ mrr: number[]; subscribers: number[] }>({ mrr: [], subscribers: [] });
   const [combinedLegend, setCombinedLegend] = useState<string>('');
   const [tierLegend, setTierLegend] = useState<string>('');
   const mrrCustRef = useRef<HTMLCanvasElement>(null);
@@ -122,7 +120,6 @@ export default function Dashboard() {
       form.conversion_rate,
       form.marketing_budget
     );
-    const blendedCpl = tierMetrics.totalLeads ? form.marketing_budget / tierMetrics.totalLeads : 0;
     const blendedCvr = tierMetrics.totalLeads ? (tierMetrics.totalNewCustomers / tierMetrics.totalLeads) * 100 : 0;
 
     const results = runSubscriptionModel(modelInput);
@@ -135,25 +132,23 @@ export default function Dashboard() {
 
     setMetrics({
       total_mrr: results.metrics.total_mrr,
-      active_customers: results.metrics.total_customers,
       annual_revenue: results.metrics.annual_revenue,
-      ltv: results.metrics.customer_ltv,
-      total_customers: results.metrics.total_customers,
+      subscriber_ltv: results.metrics.subscriber_ltv,
+      total_subscribers: results.metrics.total_subscribers,
       npv: financial.npv,
       paybackMonths: financial.paybackMonths,
-      blended_cpl: blendedCpl,
       blended_cvr: blendedCvr,
     });
 
     const labels = results.projections.monthLabels;
     const mrrArr = results.projections.mrr_by_month;
-    const custArr = results.projections.customers_by_month;
+    const subArr = results.projections.customers_by_month;
     const tierArr = results.projections.tier_revenue_by_month;
     const tierPrices = results.projections.tier_revenues_end;
     const tierCustomers = tierArr.map((arr, idx) =>
-      arr.map((val) => val / (tierPrices[idx] || 1))
+      arr.map((val) => Math.round(val / (tierPrices[idx] || 1)))
     );
-    setProjections({ mrr: mrrArr, customers: custArr });
+    setProjections({ mrr: mrrArr, subscribers: subArr });
 
     if (mrrCustRef.current) {
       const ctx = mrrCustRef.current.getContext('2d');
@@ -195,7 +190,13 @@ export default function Dashboard() {
                     callback: (v: any) => '$' + formatCurrency(Number(v)),
                   },
                 },
-                y2: { position: 'right', grid: { drawOnChartArea: false } },
+                y2: {
+                  position: 'right',
+                  grid: { drawOnChartArea: false },
+                  ticks: {
+                    callback: (v: any) => Math.round(Number(v)).toLocaleString(),
+                  },
+                },
               },
             },
           });
@@ -273,18 +274,12 @@ export default function Dashboard() {
   return (
     <div className="space-y-6">
       {metrics && (
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-7 gap-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-3 gap-4">
           <KPIChip
             labelTop="Total"
             labelBottom="MRR"
             value={metrics.total_mrr}
             dataArray={projections.mrr}
-          />
-          <KPIChip
-            labelTop="Active"
-            labelBottom="Customers"
-            value={metrics.active_customers}
-            dataArray={projections.customers}
           />
           <KPIChip
             labelTop="Annual"
@@ -293,29 +288,22 @@ export default function Dashboard() {
             dataArray={projections.mrr.map((v) => v * 12)}
           />
           <KPIChip
-            labelTop="Customer"
+            labelTop="Subscriber"
             labelBottom="LTV"
-            value={metrics.ltv}
+            value={metrics.subscriber_ltv}
             dataArray={projections.mrr.map((v) => v / (form.churn_rate_smb / 100))}
           />
           <KPIChip
             labelTop="Total"
-            labelBottom="Customers"
-            value={metrics.total_customers}
-            dataArray={projections.customers}
-          />
-          <KPIChip
-            labelTop="Blended"
-            labelBottom="CPL"
-            value={metrics.blended_cpl}
-            dataArray={projections.customers}
-            unit="currency"
+            labelBottom="Subscribers"
+            value={metrics.total_subscribers}
+            dataArray={projections.subscribers}
           />
           <KPIChip
             labelTop="Blended"
             labelBottom="CVR"
             value={metrics.blended_cvr}
-            dataArray={projections.customers}
+            dataArray={projections.subscribers}
             unit="percent"
           />
         </div>
@@ -351,7 +339,7 @@ export default function Dashboard() {
           </div>
         </SidePanel>
         <div className="flex-1 space-y-4">
-          <ChartCard title="MRR & Customers" legend={combinedLegend}>
+          <ChartCard title="MRR & Subscribers" legend={combinedLegend}>
             <canvas ref={mrrCustRef}></canvas>
           </ChartCard>
           <ChartCard title="Revenue by Tier" legend={tierLegend}>

--- a/frontend/src/model/subscription.ts
+++ b/frontend/src/model/subscription.ts
@@ -23,10 +23,10 @@ export interface SubscriptionResult {
   };
   metrics: {
     total_mrr: number;
-    total_customers: number;
+    total_subscribers: number;
     annual_revenue: number;
-    customer_ltv: number;
-    new_customers_monthly: number;
+    subscriber_ltv: number;
+    new_subscribers_monthly: number;
   };
 }
 
@@ -86,13 +86,13 @@ export function runSubscriptionModel(input: SubscriptionInput): SubscriptionResu
     },
     metrics: {
       total_mrr: mrr_by_month[mrr_by_month.length - 1],
-      total_customers: customers_by_month[customers_by_month.length - 1],
+      total_subscribers: customers_by_month[customers_by_month.length - 1],
       annual_revenue: mrr_by_month.slice(0, 12).reduce((a, b) => a + b, 0),
-      customer_ltv:
-        ((mrr_by_month.reduce((a, b) => a + b, 0) / months) *
+      subscriber_ltv:
+        (avgRevenuePerCustomer *
           (1 - (input.operating_expense_rate ?? 0) / 100)) /
         (churn || 1),
-      new_customers_monthly:
+      new_subscribers_monthly:
         customers_by_month[1] - (input.initial_customers || 10),
     },
   };

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -25,10 +25,10 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .metric-label{font-size:0.875rem;color:var(--neutral-400);font-family:'Roboto Mono',monospace;}
 
 /* KPI chips */
-.kpi-card{position:relative;background:var(--neutral-50);border:1px solid var(--neutral-200);border-radius:8px;padding:1rem;overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;}
-.kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-neutral-500);font-family:'Roboto Mono',monospace;}
+.kpi-card{position:relative;background:var(--neutral-50);border:1px solid var(--neutral-200);border-radius:8px;padding:var(--space-sm) var(--space-md);overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;}
+.kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-neutral-500);font-family:'Roboto Mono',monospace;line-height:1;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
-.kpi-card .top-row{display:flex;justify-content:space-between;align-items:flex-end;}
+.kpi-card .top-row{display:flex;justify-content:space-between;align-items:center;}
 
 /* interactive card */
 .interactive-card>.card-header{all:unset;display:flex;justify-content:space-between;

--- a/static/js/chart-manager.js
+++ b/static/js/chart-manager.js
@@ -25,7 +25,7 @@ try {
 }
 export const palette = computedPalette;
 
-export function buildArea(ctx, labels, data, col) {
+export function buildArea(ctx, labels, data, col, formatter) {
   return new Chart(ctx, {
     type: "line",
     data: {
@@ -44,9 +44,14 @@ export function buildArea(ctx, labels, data, col) {
       plugins: { legend: { display: false } },
       scales: {
         x: { grid: { display: false } },
-        y: { 
+        y: {
           grid: { color: "#ECECEC" }, // Playbook defined
-          ticks: { callback: v => v != null ? ("$" + v.toLocaleString()) : "$0" } // Playbook defined, ensure v is not null/undefined
+          ticks: {
+            callback: v => {
+              const fn = formatter || (val => "$" + val.toLocaleString());
+              return fn(v);
+            }
+          }
         }
       }
     }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -117,12 +117,12 @@ function calc(formData) {
       mrrArr: combinedResults.projections?.mrr_by_month || [],
       custArr: combinedResults.projections?.customers_by_month || [],
       tierArr: combinedResults.projections?.tier_revenues_end || [],
-      metrics: { 
+      metrics: {
           total_mrr: combinedResults.metrics?.total_mrr || 0,
-          active_customers: combinedResults.metrics?.total_customers || 0,
+          total_subscribers: combinedResults.metrics?.total_subscribers || 0,
           annual_revenue: combinedResults.metrics?.annual_revenue || 0,
-          ltv: combinedResults.metrics?.customer_ltv || 0, // Mapped from customer_ltv
-          new_cust_month: combinedResults.metrics?.new_customers_monthly || 0 // Mapped from new_customers_monthly
+          subscriber_ltv: combinedResults.metrics?.subscriber_ltv || 0,
+          new_sub_month: combinedResults.metrics?.new_subscribers_monthly || 0
       }
   };
 }
@@ -155,7 +155,7 @@ function render(result) {
 
     const custCtx = document.getElementById("customersChart")?.getContext("2d");
     if (custCtx) {
-        if (!charts.cust) charts.cust = buildArea(custCtx, result.labels, result.custArr, palette[1]);
+        if (!charts.cust) charts.cust = buildArea(custCtx, result.labels, result.custArr, palette[1], v => Number(v).toLocaleString());
         else { charts.cust.data.labels = result.labels; charts.cust.data.datasets[0].data = result.custArr; charts.cust.update(); }
     }
 

--- a/static/js/model/subscription.js
+++ b/static/js/model/subscription.js
@@ -36,12 +36,12 @@ export function runSubscriptionModel(input) {
     },
     metrics: {
       total_mrr: mrr_by_month[mrr_by_month.length-1],
-      total_customers: customers_by_month[customers_by_month.length-1],
+      total_subscribers: customers_by_month[customers_by_month.length-1],
       annual_revenue: mrr_by_month.slice(0,12).reduce((a,b)=>a+b,0),
-      customer_ltv:
-        ((mrr_by_month.reduce((a,b)=>a+b,0)/months) * (1 - (input.operating_expense_rate||0)/100)) /
+      subscriber_ltv:
+        (avgRevenuePerCustomer * (1 - (input.operating_expense_rate||0)/100)) /
         (churn || 1),
-      new_customers_monthly: monthlyAcquisition
+      new_subscribers_monthly: monthlyAcquisition
     }
   };
 }


### PR DESCRIPTION
## Summary
- replace customer terminology with subscriber
- compute subscriber LTV using blended revenue per tier
- show five KPI chips in a responsive grid
- adjust KPI card spacing and alignment
- round subscriber values in charts

## Testing
- `npm test --silent --prefix frontend` *(fails: jest not found)*
- `pytest -q` *(fails: command not found)*