### PR TITLE
Fix KPI display and sparkline trends

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -280,18 +280,21 @@ export default function Dashboard() {
             labelBottom="MRR"
             value={metrics.total_mrr}
             dataArray={projections.mrr}
+            unit="currency"
           />
           <KPIChip
             labelTop="Annual"
             labelBottom="Revenue"
             value={metrics.annual_revenue}
             dataArray={projections.mrr.map((v) => v * 12)}
+            unit="currency"
           />
           <KPIChip
             labelTop="Subscriber"
             labelBottom="LTV"
             value={metrics.subscriber_ltv}
             dataArray={projections.mrr.map((v) => v / (form.churn_rate_smb / 100))}
+            unit="currency"
           />
           <KPIChip
             labelTop="Total"

--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -28,11 +28,18 @@ export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit 
   const displayValue =
     typeof value === 'number'
       ? unit === 'currency'
-        ? formatCurrency(value)
+        ? '$' + formatCurrency(value)
+        : unit === 'percent'
+        ? value.toFixed(2) + '%'
         : formatNumberShort(value)
       : value;
 
-  const sparkData = [...dataArray].reverse();
+  const sparkData = [...dataArray];
+
+  const trendUp = sparkData[sparkData.length - 1] >= sparkData[0];
+  const sparkColor = trendUp
+    ? 'var(--success-500)'
+    : 'var(--error-500)';
 
   return (
     <div
@@ -51,6 +58,8 @@ export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit 
         data={sparkData}
         onRendered={handleRendered}
         className="sparkline"
+        color={sparkColor}
+        strokeWidth={3}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- show currency KPIs with dollar sign
- show percent KPIs with two decimals
- color and size KPI sparklines based on trend
- expose sparkline color/width props

## Testing
- `npm --prefix frontend test` *(fails: jest not found)*
- `python -m pytest -q` *(fails: No module named pytest)*