### PR TITLE
Move KPIs into chart column and tweak sidebar styles

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -273,46 +273,8 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-6">
-      {metrics && (
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-3 gap-4">
-          <KPIChip
-            labelTop="Total"
-            labelBottom="MRR"
-            value={metrics.total_mrr}
-            dataArray={projections.mrr}
-            unit="currency"
-          />
-          <KPIChip
-            labelTop="Annual"
-            labelBottom="Revenue"
-            value={metrics.annual_revenue}
-            dataArray={projections.mrr.map((v) => v * 12)}
-            unit="currency"
-          />
-          <KPIChip
-            labelTop="Subscriber"
-            labelBottom="LTV"
-            value={metrics.subscriber_ltv}
-            dataArray={projections.mrr.map((v) => v / (form.churn_rate_smb / 100))}
-            unit="currency"
-          />
-          <KPIChip
-            labelTop="Total"
-            labelBottom="Subscribers"
-            value={metrics.total_subscribers}
-            dataArray={projections.subscribers}
-          />
-          <KPIChip
-            labelTop="Blended"
-            labelBottom="CVR"
-            value={metrics.blended_cvr}
-            dataArray={projections.subscribers}
-            unit="percent"
-          />
-        </div>
-      )}
       <div className="lg:flex gap-4">
-        <SidePanel className="sticky top-4 lg:w-[260px] w-full max-h-[calc(100vh-140px)] overflow-y-auto">
+        <SidePanel className="side-panel sticky top-4 lg:w-[260px] w-full max-h-[calc(100vh-140px)] overflow-y-auto">
           <div className="space-y-3 mb-6">
             <h3 className="text-sm font-semibold mb-2 font-sans">Pricing Tiers</h3>
             {[1, 2, 3, 4].map((n) => (
@@ -342,6 +304,37 @@ export default function Dashboard() {
           </div>
         </SidePanel>
         <div className="flex-1 space-y-4">
+          {metrics && (
+            <div className="grid grid-cols-2 gap-4 mb-4">
+              <KPIChip
+                labelTop="Total"
+                labelBottom="MRR"
+                value={metrics.total_mrr}
+                dataArray={projections.mrr}
+                unit="currency"
+              />
+              <KPIChip
+                labelTop="Annual"
+                labelBottom="Revenue"
+                value={metrics.annual_revenue}
+                dataArray={projections.mrr.map((v) => v * 12)}
+                unit="currency"
+              />
+              <KPIChip
+                labelTop="Subscriber"
+                labelBottom="LTV"
+                value={metrics.subscriber_ltv}
+                dataArray={projections.mrr.map((v) => v / (form.churn_rate_smb / 100))}
+                unit="currency"
+              />
+              <KPIChip
+                labelTop="Total"
+                labelBottom="Subscribers"
+                value={metrics.total_subscribers}
+                dataArray={projections.subscribers}
+              />
+            </div>
+          )}
           <ChartCard title="MRR & Subscribers" legend={combinedLegend}>
             <canvas ref={mrrCustRef}></canvas>
           </ChartCard>

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -182,3 +182,15 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .chip.editing input{
   opacity:1;
 }
+
+/* mobile font scaling for sidebar */
+.side-panel .chip .label,
+.side-panel .chip .value {
+  font-size:0.875rem;
+}
+@media(min-width:1024px){
+  .side-panel .chip .label,
+  .side-panel .chip .value{
+    font-size:1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- remove Blended CVR KPI card and move remaining KPIs into the chart column
- add `.side-panel` class and mobile font scaling

## Testing
- `npx jest --runInBand` *(fails: request to https://registry.npmjs.org/jest failed)*