### PR TITLE
Allow fractional customer values

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -146,7 +146,7 @@ export default function Dashboard() {
     const tierArr = results.projections.tier_revenue_by_month;
     const tierPrices = results.projections.tier_revenues_end;
     const tierCustomers = tierArr.map((arr, idx) =>
-      arr.map((val) => Math.round(val / (tierPrices[idx] || 1)))
+      arr.map((val) => val / (tierPrices[idx] || 1))
     );
     setProjections({ mrr: mrrArr, subscribers: subArr });
 
@@ -194,7 +194,7 @@ export default function Dashboard() {
                   position: 'right',
                   grid: { drawOnChartArea: false },
                   ticks: {
-                    callback: (v: any) => Math.round(Number(v)).toLocaleString(),
+                    callback: (v: any) => Number(v).toLocaleString(),
                   },
                 },
               },

--- a/frontend/src/model/__tests__/subscription.test.ts
+++ b/frontend/src/model/__tests__/subscription.test.ts
@@ -10,7 +10,8 @@ test('customer roll-forward logic', () => {
     cpl: 100,
     conversion_rate: 10,
   });
-  expect(result.projections.customers_by_month).toEqual([100, 100]);
+  expect(result.projections.customers_by_month[0]).toBeCloseTo(90.521875);
+  expect(result.projections.customers_by_month[1]).toBeCloseTo(81.9915625);
 });
 
 test('MRR matches sum of tier revenues', () => {

--- a/frontend/src/model/subscription.ts
+++ b/frontend/src/model/subscription.ts
@@ -65,7 +65,7 @@ export function runSubscriptionModel(input: SubscriptionInput): SubscriptionResu
     const churned = Math.min(customers, customers * churn);
     const next = Math.max(0, customers + monthlyAcquisition - churned);
     customers = next;
-    customers_by_month.push(Math.round(customers));
+    customers_by_month.push(customers);
     const recognized = customers * avgRevenuePerCustomer;
     mrr_by_month.push(recognized);
     deferred_by_month.push(recognized); // simplified deferral


### PR DESCRIPTION
## Summary
- keep fractional values in subscription projections
- show fractional subscriber counts on charts
- update subscription model tests for fractional results

## Testing
- `npm --version` *(fails: command not found)*
- `npx jest -h` *(fails: no dependencies)*