### PR TITLE
Adjust KPI visuals and tier inputs

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -24,6 +24,8 @@ import { generateLegend } from './utils/chartLegend';
 import { formatCurrency } from './utils/format';
 import { getCssVar } from './utils/cssVar';
 
+const TIER_COLORS = ['#4A47DC', '#8D8BE9', '#BF7DC4', '#E3C7E6'];
+
 interface FormState {
   tier1_revenue: number;
   tier2_revenue: number;
@@ -280,10 +282,20 @@ export default function Dashboard() {
             {[1, 2, 3, 4].map((n) => (
               <InlineNumberInput
                 key={n}
-                label={`Tier ${n}`}
+                label={(
+                  <>
+                    <span
+                      className="swatch"
+                      style={{ backgroundColor: TIER_COLORS[n - 1] }}
+                    ></span>
+                    {`Tier ${n}`}
+                  </>
+                )}
                 unit="currency"
                 value={form[`tier${n}_revenue` as keyof FormState] as number}
-                onChange={(v) => handleValueChange(`tier${n}_revenue` as keyof FormState, v)}
+                onChange={(v) =>
+                  handleValueChange(`tier${n}_revenue` as keyof FormState, v)
+                }
               />
             ))}
           </div>

--- a/frontend/src/components/InlineNumberInput.tsx
+++ b/frontend/src/components/InlineNumberInput.tsx
@@ -1,8 +1,8 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, ReactNode } from 'react';
 import { formatCurrency, formatNumberShort } from '../utils/format';
 
 interface Props {
-  label: string;
+  label: ReactNode;
   value: number;
   unit?: 'currency' | 'percent';
   onChange: (value: number) => void;
@@ -14,7 +14,8 @@ export default function InlineNumberInput({ label, value, unit, onChange, name, 
   const [editing, setEditing] = useState(false);
   const [temp, setTemp] = useState<number>(value);
   const inputRef = useRef<HTMLInputElement>(null);
-  const safeName = (name || label).replace(/\s+/g, '_').toLowerCase();
+  const baseLabel = typeof label === 'string' ? label : 'input';
+  const safeName = (name || baseLabel).replace(/\s+/g, '_').toLowerCase();
   const inputId = id || safeName;
 
   const display = unit === 'currency' ? formatCurrency(value) :

--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -59,7 +59,7 @@ export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit 
         onRendered={handleRendered}
         className="sparkline"
         color={sparkColor}
-        strokeWidth={3}
+        strokeWidth={5}
       />
     </div>
   );

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -2,26 +2,6 @@ import { useRef, useEffect } from 'react';
 import { Chart } from 'chart.js/auto';
 import { getCssVar } from '../utils/cssVar';
 
-function parseColor(color: string): [number, number, number] {
-  const c = color?.trim() || '';
-  const rgbMatch = c.match(/^rgba?\((\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})(?:\s*,\s*[\d.]+)?\)$/i);
-  if (rgbMatch) {
-    const r = parseInt(rgbMatch[1], 10);
-    const g = parseInt(rgbMatch[2], 10);
-    const b = parseInt(rgbMatch[3], 10);
-    if (!isNaN(r) && !isNaN(g) && !isNaN(b)) return [r, g, b];
-  }
-  const hexMatch = c.match(/^#([0-9a-f]{6})$/i);
-  if (hexMatch) {
-    const hex = hexMatch[1];
-    const r = parseInt(hex.substring(0, 2), 16);
-    const g = parseInt(hex.substring(2, 4), 16);
-    const b = parseInt(hex.substring(4, 6), 16);
-    return [r, g, b];
-  }
-  return [0, 0, 0];
-}
-
 interface Props {
   data: number[];
   className?: string;
@@ -49,10 +29,6 @@ export default function Sparkline({
 
     const ctx = ref.current.getContext('2d');
     if (!ctx) return;
-    const [r, g, b] = parseColor(resolvedColor);
-    const gradient = ctx.createLinearGradient(0, 0, 0, ref.current.height);
-    gradient.addColorStop(0, `rgba(${r},${g},${b},0.15)`);
-    gradient.addColorStop(1, `rgba(${r},${g},${b},0)`);
 
     const animation = {
       duration: 200,
@@ -69,11 +45,11 @@ export default function Sparkline({
             {
               data,
               borderColor: resolvedColor,
-              backgroundColor: gradient,
+              backgroundColor: 'transparent',
               borderWidth: strokeWidth,
               tension: 0.4,
               pointRadius: 0,
-              fill: 'origin',
+              fill: false,
               capBezierPoints: true,
             },
           ],
@@ -93,7 +69,7 @@ export default function Sparkline({
       const c = chartRef.current;
       c.data.labels = labels;
       (c.data.datasets[0].data as number[]) = data;
-      (c.data.datasets[0].backgroundColor as any) = gradient;
+      (c.data.datasets[0].backgroundColor as any) = 'transparent';
       (c.data.datasets[0].borderColor as any) = resolvedColor;
       (c.data.datasets[0].borderWidth as any) = strokeWidth;
       c.options!.animation = animation;


### PR DESCRIPTION
## Summary
- tweak KPI sparkline thickness and remove fill
- allow InlineNumberInput labels to accept React nodes
- show color chips for each pricing tier input
- remove gradient from Sparkline component

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*