### PR TITLE
Refine typography and layout

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -318,13 +318,14 @@ export default function Dashboard() {
         </SidePanel>
         <div className="flex-1 space-y-4">
           {metrics && (
-            <div className="grid grid-cols-2 gap-4 mb-4">
+            <div className="grid grid-cols-12 gap-4 mb-4">
               <KPIChip
                 labelTop="Total"
                 labelBottom="MRR"
                 value={metrics.total_mrr}
                 dataArray={projections.mrr}
                 unit="currency"
+                className="col-span-6 lg:col-span-3"
               />
               <KPIChip
                 labelTop="Annual"
@@ -332,6 +333,7 @@ export default function Dashboard() {
                 value={metrics.annual_revenue}
                 dataArray={projections.mrr.map((v) => v * 12)}
                 unit="currency"
+                className="col-span-6 lg:col-span-3"
               />
               <KPIChip
                 labelTop="Subscriber"
@@ -339,12 +341,14 @@ export default function Dashboard() {
                 value={metrics.subscriber_ltv}
                 dataArray={projections.mrr.map((v) => v / (form.churn_rate_smb / 100))}
                 unit="currency"
+                className="col-span-6 lg:col-span-3"
               />
               <KPIChip
                 labelTop="Total"
                 labelBottom="Subscribers"
                 value={metrics.total_subscribers}
                 dataArray={projections.subscribers}
+                className="col-span-6 lg:col-span-3"
               />
             </div>
           )}

--- a/frontend/src/components/ChartCard.tsx
+++ b/frontend/src/components/ChartCard.tsx
@@ -11,7 +11,7 @@ export default function ChartCard({ title, children, legend }: Props) {
   return (
     <div>
       <div className="flex justify-between items-center mb-2">
-        <h3 className="text-sm font-medium font-sans">{title}</h3>
+        <h3 className="content-header">{title}</h3>
         {legend && (
           <div
             className="text-xs font-mono text-[var(--squid-ink)]"

--- a/frontend/src/components/EquationReport.tsx
+++ b/frontend/src/components/EquationReport.tsx
@@ -3,7 +3,7 @@ import Card from './Card';
 export default function EquationReport() {
   return (
     <div>
-      <h3 className="text-sm font-medium font-sans mb-2">Model Equations</h3>
+      <h3 className="content-header">Model Equations</h3>
       <Card>
         <ul className="text-sm list-disc pl-6 space-y-1 font-mono">
           <li>New Customers = (Marketing Budget / Cost Per Lead) × Conversion Rate</li>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,8 +4,8 @@ export default function Header() {
   return (
     <header className="flex items-center justify-between py-4">
       <div>
-        <h1 className="font-bold text-[32px] leading-[1.2] font-sans">SMB Program Modeling</h1>
-        <p className="font-medium text-sm leading-[1.4] text-[var(--color-neutral-500)] font-mono">Carbon Removal Subscription Service</p>
+        <h1 className="main-header">SMB Program Modeling</h1>
+        <p className="sub-header">Carbon Removal Subscription Service</p>
       </div>
       <ApiStatus />
     </header>

--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -8,9 +8,10 @@ interface Props {
   value: number | string;
   dataArray: number[];
   unit?: 'currency' | 'percent';
+  className?: string;
 }
 
-export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit }: Props) {
+export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit, className = '' }: Props) {
   const [refreshing, setRefreshing] = useState(true);
   const prevData = useRef<number[]>([]);
 
@@ -43,7 +44,7 @@ export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit 
 
   return (
     <div
-      className={`kpi-card ${refreshing ? 'refreshing' : ''}`}
+      className={`kpi-card ${refreshing ? 'refreshing' : ''} ${className}`}
     >
       <div className="top-row">
         <div className="label-block">


### PR DESCRIPTION
## Summary
- bring typography classes into components
- tune metric grid layout for consistent sizing
- pass layout class to KPIChip components

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: command not found)*