### PR TITLE
Enhance dashboard with funnel metrics

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -100,6 +100,7 @@ class ProjectionRequest(BaseModel):
     marketing_budget: float
     base_cpl: float
     base_cvr: float
+    ctr: float = 1.0
     months: int = 24
 
 
@@ -181,4 +182,5 @@ async def projection(data: ProjectionRequest):
         months=data.months,
         base_cpl=data.base_cpl,
         base_cvr=data.base_cvr,
+        ctr=data.ctr,
     )

--- a/backend/app/marketing.py
+++ b/backend/app/marketing.py
@@ -12,13 +12,28 @@ BENCHMARK_RANGES: List[Dict[str, Tuple[float, float]]] = [
 ]
 
 
+def derive_cpl_by_tier(base_cpl: float) -> List[float]:
+    """Return CPL values for each tier based on base CPL."""
+    return [base_cpl * f for f in TIER_CPL_FACTORS]
+
+
+def derive_cvr_by_tier(base_cvr: float) -> List[float]:
+    """Return CVR percentages for each tier based on base CVR."""
+    return [max(base_cvr * f, 0.1) for f in TIER_CVR_FACTORS]
+
+
+def split_budget(total: float) -> List[float]:
+    """Split total budget according to the default ratio."""
+    return [total * s for s in TIER_BUDGET_SPLIT]
+
+
 def calculate_tier_metrics(
     base_cpl: float, base_cvr: float, total_budget: float
 ) -> Dict[str, object]:
     """Calculate CPL, CVR, leads and new customers for each tier."""
-    cpl = [base_cpl * f for f in TIER_CPL_FACTORS]
-    cvr = [max(base_cvr * f, 0.1) for f in TIER_CVR_FACTORS]
-    budgets = [total_budget * s for s in TIER_BUDGET_SPLIT]
+    cpl = derive_cpl_by_tier(base_cpl)
+    cvr = derive_cvr_by_tier(base_cvr)
+    budgets = split_budget(total_budget)
     leads = [b / c if c else 0 for b, c in zip(budgets, cpl)]
     new_customers: List[float] = []
     for b, c, r in zip(budgets, cpl, cvr):

--- a/backend/app/projection.py
+++ b/backend/app/projection.py
@@ -11,10 +11,10 @@ from .marketing import (
 BASE_CPL = 150.0
 BASE_CVR = 2.75
 TIER_PRICES = [500.0, 1200.0, 3000.0, 7500.0]
-MONTHLY_CHURN = 0.03
-OPERATING_EXPENSE_RATE = 0.35
-FIXED_COSTS = 4167.0
-MONTHLY_WACC = 0.00643
+MONTHLY_CHURN = 0.10
+OPERATING_EXPENSE_RATE = 0.15
+FIXED_COSTS = 1500.0
+MONTHLY_WACC = 0.08 / 12
 PROJECTION_MONTHS = 24
 INITIAL_INVESTMENT = 200000.0
 CPI = 8.0  # cost per 1000 impressions
@@ -26,6 +26,7 @@ def run_projection(
     months: int = PROJECTION_MONTHS,
     base_cpl: float = BASE_CPL,
     base_cvr: float = BASE_CVR,
+    ctr: float = 1.0,
 ) -> Dict[str, List[float]]:
     flags = guardrail_flags(base_cpl, base_cvr)
     tier_cpl = [base_cpl * f for f in TIER_CPL_FACTORS]
@@ -46,7 +47,7 @@ def run_projection(
 
     for _ in range(months):
         imp = (marketing_budget / CPI) * 1000
-        clk = imp  # CTR not specified; assume 1
+        clk = imp * (ctr / 100.0)
         budgets = [marketing_budget * s for s in TIER_BUDGET_SPLIT]
         leads = [b / c if c else 0 for b, c in zip(budgets, tier_cpl)]
         new_cust = [l * (cv / 100.0) for l, cv in zip(leads, tier_cvr)]

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from "react";
 import {
   DEFAULT_TIER_REVENUES,
   DEFAULT_MARKETING_BUDGET,
@@ -11,21 +11,23 @@ import {
   DEFAULT_OPERATING_EXPENSE_RATE,
   DEFAULT_FIXED_COSTS,
   DEFAULT_TIER_ADOPTION,
-} from './model/constants';
-import { runSubscriptionModel } from './model/subscription';
-import { calculateFinancialMetrics } from './model/finance';
-import { calculateTierMetrics } from './model/marketing';
-import { Chart } from 'chart.js/auto';
-import KPIChip from './components/KPIChip';
-import SidePanel from './components/SidePanel';
-import InlineNumberInput from './components/InlineNumberInput';
-import ChartCard from './components/ChartCard';
-import EquationReport from './components/EquationReport';
-import { generateLegend } from './utils/chartLegend';
-import { formatCurrency } from './utils/format';
-import { getCssVar } from './utils/cssVar';
+  DEFAULT_CTR,
+  COST_PER_MILLE,
+} from "./model/constants";
+import { runSubscriptionModel } from "./model/subscription";
+import { calculateFinancialMetrics } from "./model/finance";
+import { calculateTierMetrics } from "./model/marketing";
+import { Chart } from "chart.js/auto";
+import KPIChip from "./components/KPIChip";
+import SidePanel from "./components/SidePanel";
+import InlineNumberInput from "./components/InlineNumberInput";
+import ChartCard from "./components/ChartCard";
+import EquationReport from "./components/EquationReport";
+import { generateLegend } from "./utils/chartLegend";
+import { formatCurrency } from "./utils/format";
+import { getCssVar } from "./utils/cssVar";
 
-const TIER_COLORS = ['#4A47DC', '#8D8BE9', '#BF7DC4', '#E3C7E6'];
+const TIER_COLORS = ["#4A47DC", "#8D8BE9", "#BF7DC4", "#E3C7E6"];
 
 interface FormState {
   tier1_revenue: number;
@@ -35,6 +37,7 @@ interface FormState {
   marketing_budget: number;
   cpl: number;
   conversion_rate: number;
+  ctr: number;
   churn_rate_smb: number;
   wacc: number;
   projection_months: number;
@@ -50,6 +53,7 @@ interface Metrics {
   npv: number;
   paybackMonths: number | null;
   blended_cvr: number;
+  blended_cpl: number;
 }
 
 export default function Dashboard() {
@@ -61,6 +65,7 @@ export default function Dashboard() {
     marketing_budget: DEFAULT_MARKETING_BUDGET,
     cpl: DEFAULT_COST_PER_LEAD,
     conversion_rate: DEFAULT_CONVERSION_RATE,
+    ctr: DEFAULT_CTR,
     churn_rate_smb: DEFAULT_MONTHLY_CHURN_RATE,
     wacc: DEFAULT_WACC,
     projection_months: DEFAULT_PROJECTION_MONTHS,
@@ -69,30 +74,32 @@ export default function Dashboard() {
   });
 
   const [metrics, setMetrics] = useState<Metrics | null>(null);
-  const [projections, setProjections] = useState<{ mrr: number[]; subscribers: number[] }>({ mrr: [], subscribers: [] });
-  const [combinedLegend, setCombinedLegend] = useState<string>('');
-  const [tierLegend, setTierLegend] = useState<string>('');
+  const [projections, setProjections] = useState<{
+    mrr: number[];
+    subscribers: number[];
+    impressions: number[];
+    clicks: number[];
+    leads: number[];
+    newCustomers: number[];
+  }>({
+    mrr: [],
+    subscribers: [],
+    impressions: [],
+    clicks: [],
+    leads: [],
+    newCustomers: [],
+  });
+  const [combinedLegend, setCombinedLegend] = useState<string>("");
+  const [tierLegend, setTierLegend] = useState<string>("");
   const mrrCustRef = useRef<HTMLCanvasElement>(null);
   const tierRef = useRef<HTMLCanvasElement>(null);
   const chartInstances = useRef<{ combined?: Chart; tier?: Chart }>({});
-  const warned = useRef(false);
+  const [warning, setWarning] = useState(false);
 
   useEffect(() => {
-    if (form.cpl < 50 || form.conversion_rate > 10) {
-      if (!warned.current) {
-        alert('Base CPL must be at least $50 and base CVR at most 10%');
-        warned.current = true;
-      }
-      return;
-    }
-    if (form.conversion_rate > 15 || form.churn_rate_smb < 1) {
-      if (!warned.current) {
-        alert('Inputs look unrealistic');
-        warned.current = true;
-      }
-      return;
-    }
-    warned.current = false;
+    const badCpl = form.cpl < 50 || form.cpl > 300;
+    const badCvr = form.conversion_rate < 0.1 || form.conversion_rate > 6;
+    setWarning(badCpl || badCvr);
     const modelInput = {
       tier_revenues: [
         form.tier1_revenue,
@@ -103,6 +110,7 @@ export default function Dashboard() {
       marketing_budget: form.marketing_budget,
       cpl: form.cpl,
       conversion_rate: form.conversion_rate,
+      ctr: form.ctr,
       churn_rate_smb: form.churn_rate_smb,
       wacc: form.wacc,
       initial_cac_smb: 0,
@@ -121,16 +129,21 @@ export default function Dashboard() {
     const tierMetrics = calculateTierMetrics(
       form.cpl,
       form.conversion_rate,
-      form.marketing_budget
+      form.marketing_budget,
     );
-    const blendedCvr = tierMetrics.totalLeads ? (tierMetrics.totalNewCustomers / tierMetrics.totalLeads) * 100 : 0;
+    const blendedCvr = tierMetrics.totalLeads
+      ? (tierMetrics.totalNewCustomers / tierMetrics.totalLeads) * 100
+      : 0;
+    const blendedCpl = tierMetrics.totalLeads
+      ? form.marketing_budget / tierMetrics.totalLeads
+      : 0;
 
     const results = runSubscriptionModel(modelInput);
     const financial = calculateFinancialMetrics(
       results,
       DEFAULT_INITIAL_INVESTMENT,
       expenses,
-      form.wacc
+      form.wacc,
     );
 
     setMetrics({
@@ -141,6 +154,7 @@ export default function Dashboard() {
       npv: financial.npv,
       paybackMonths: financial.paybackMonths,
       blended_cvr: blendedCvr,
+      blended_cpl: blendedCpl,
     });
 
     const labels = results.projections.monthLabels;
@@ -149,37 +163,44 @@ export default function Dashboard() {
     const tierArr = results.projections.tier_revenue_by_month;
     const tierPrices = results.projections.tier_revenues_end;
     const tierCustomers = tierArr.map((arr, idx) =>
-      arr.map((val) => val / (tierPrices[idx] || 1))
+      arr.map((val) => val / (tierPrices[idx] || 1)),
     );
-    setProjections({ mrr: mrrArr, subscribers: subArr });
+    setProjections({
+      mrr: mrrArr,
+      subscribers: subArr,
+      impressions: results.projections.impressions_by_month,
+      clicks: results.projections.clicks_by_month,
+      leads: results.projections.leads_by_month,
+      newCustomers: results.projections.new_customers_by_month,
+    });
 
     if (mrrCustRef.current) {
-      const ctx = mrrCustRef.current.getContext('2d');
+      const ctx = mrrCustRef.current.getContext("2d");
       if (ctx) {
-        const mrrColor = getCssVar('--success-500', mrrCustRef.current!);
+        const mrrColor = getCssVar("--success-500", mrrCustRef.current!);
         const datasets = [
           {
-            label: 'MRR',
+            label: "MRR",
             data: mrrArr,
             borderColor: mrrColor,
             borderWidth: 4,
-            yAxisID: 'y1',
+            yAxisID: "y1",
             pointRadius: 0,
             pointHoverRadius: 4,
           },
           ...tierCustomers.map((arr, idx) => ({
             label: `Tier ${idx + 1}`,
             data: arr,
-            borderColor: ['#4A47DC', '#8D8BE9', '#BF7DC4', '#E3C7E6'][idx],
+            borderColor: ["#4A47DC", "#8D8BE9", "#BF7DC4", "#E3C7E6"][idx],
             borderWidth: 2,
-            yAxisID: 'y2',
+            yAxisID: "y2",
             pointRadius: 0,
             pointHoverRadius: 4,
           })),
         ];
         if (!chartInstances.current.combined) {
           chartInstances.current.combined = new Chart(ctx, {
-            type: 'line',
+            type: "line",
             data: { labels, datasets },
             options: {
               responsive: true,
@@ -188,13 +209,13 @@ export default function Dashboard() {
               scales: {
                 x: { grid: { display: false } },
                 y1: {
-                  position: 'left',
+                  position: "left",
                   ticks: {
-                    callback: (v: any) => '$' + formatCurrency(Number(v)),
+                    callback: (v: any) => "$" + formatCurrency(Number(v)),
                   },
                 },
                 y2: {
-                  position: 'right',
+                  position: "right",
                   grid: { drawOnChartArea: false },
                   ticks: {
                     callback: (v: any) => Number(v).toLocaleString(),
@@ -216,16 +237,16 @@ export default function Dashboard() {
     }
 
     if (tierRef.current) {
-      const ctx = tierRef.current.getContext('2d');
+      const ctx = tierRef.current.getContext("2d");
       if (ctx) {
         const datasets = tierArr.map((arr: number[], idx: number) => ({
           label: `Tier ${idx + 1}`,
           data: arr,
-          backgroundColor: ['#4A47DC', '#8D8BE9', '#BF7DC4', '#E3C7E6'][idx],
+          backgroundColor: ["#4A47DC", "#8D8BE9", "#BF7DC4", "#E3C7E6"][idx],
         }));
         if (!chartInstances.current.tier) {
           chartInstances.current.tier = new Chart(ctx, {
-            type: 'bar',
+            type: "bar",
             data: { labels, datasets },
             options: {
               responsive: true,
@@ -236,7 +257,7 @@ export default function Dashboard() {
                 y: {
                   stacked: true,
                   ticks: {
-                    callback: (v: any) => '$' + formatCurrency(Number(v)),
+                    callback: (v: any) => "$" + formatCurrency(Number(v)),
                   },
                 },
               },
@@ -276,6 +297,11 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-6">
+      {warning && (
+        <div className="text-xs text-yellow-700 bg-yellow-100 py-1 px-2 rounded">
+          Input assumptions outside EY benchmark – review Marketing CPL / CVR
+        </div>
+      )}
       <div className="lg:flex gap-4">
         <SidePanel className="side-panel sticky top-4 lg:w-[260px] w-full max-h-[calc(100vh-140px)] overflow-y-auto">
           <div className="space-y-3 mb-6">
@@ -283,7 +309,7 @@ export default function Dashboard() {
             {[1, 2, 3, 4].map((n) => (
               <InlineNumberInput
                 key={n}
-                label={(
+                label={
                   <>
                     <span
                       className="swatch"
@@ -291,7 +317,7 @@ export default function Dashboard() {
                     ></span>
                     {`Tier ${n}`}
                   </>
-                )}
+                }
                 unit="currency"
                 value={form[`tier${n}_revenue` as keyof FormState] as number}
                 onChange={(v) =>
@@ -302,18 +328,73 @@ export default function Dashboard() {
           </div>
           <div className="space-y-3 mb-6">
             <h3 className="sidebar-title mb-2">Marketing</h3>
-            <InlineNumberInput label="Budget" unit="currency" value={form.marketing_budget} onChange={(v) => handleValueChange('marketing_budget', v)} />
-            <InlineNumberInput label="CPL" unit="currency" value={form.cpl} onChange={(v) => handleValueChange('cpl', v)} />
-            <InlineNumberInput label="CVR" unit="percent" value={form.conversion_rate} onChange={(v) => handleValueChange('conversion_rate', v)} />
-            <p className="text-xs text-gray-500">Upper tiers scale automatically from Tier 1 inputs.</p>
+            <InlineNumberInput
+              label="Budget"
+              unit="currency"
+              value={form.marketing_budget}
+              onChange={(v) => handleValueChange("marketing_budget", v)}
+            />
+            <InlineNumberInput
+              label="CPL"
+              unit="currency"
+              value={form.cpl}
+              onChange={(v) => handleValueChange("cpl", v)}
+            />
+            <InlineNumberInput
+              label="CVR"
+              unit="percent"
+              value={form.conversion_rate}
+              onChange={(v) => handleValueChange("conversion_rate", v)}
+            />
+            <InlineNumberInput
+              label="CTR"
+              unit="percent"
+              value={form.ctr}
+              onChange={(v) => handleValueChange("ctr", v)}
+            />
+            <p className="text-xs text-gray-500">
+              Upper tiers scale automatically: CPL factors 1 / 1.6 / 2.5 / 4.0,
+              CVR factors 1 / 0.65 / 0.35 / 0.15
+            </p>
+            <details className="text-xs text-gray-500">
+              <summary className="cursor-pointer">Advanced</summary>
+              <div className="mt-1 space-y-1">
+                <div>{`Cost per 1K impressions: $${COST_PER_MILLE}`}</div>
+                <div>Marketing split: 40 / 30 / 20 / 10</div>
+              </div>
+            </details>
           </div>
           <div className="space-y-3">
             <h3 className="sidebar-title mb-2">Financial</h3>
-            <InlineNumberInput label="Churn %" unit="percent" value={form.churn_rate_smb} onChange={(v) => handleValueChange('churn_rate_smb', v)} />
-            <InlineNumberInput label="WACC %" unit="percent" value={form.wacc} onChange={(v) => handleValueChange('wacc', v)} />
-            <InlineNumberInput label="Months" value={form.projection_months} onChange={(v) => handleValueChange('projection_months', v)} />
-            <InlineNumberInput label="Opex %" unit="percent" value={form.operating_expense_rate} onChange={(v) => handleValueChange('operating_expense_rate', v)} />
-            <InlineNumberInput label="Fixed Costs" unit="currency" value={form.fixed_costs} onChange={(v) => handleValueChange('fixed_costs', v)} />
+            <InlineNumberInput
+              label="Churn %"
+              unit="percent"
+              value={form.churn_rate_smb}
+              onChange={(v) => handleValueChange("churn_rate_smb", v)}
+            />
+            <InlineNumberInput
+              label="WACC %"
+              unit="percent"
+              value={form.wacc}
+              onChange={(v) => handleValueChange("wacc", v)}
+            />
+            <InlineNumberInput
+              label="Months"
+              value={form.projection_months}
+              onChange={(v) => handleValueChange("projection_months", v)}
+            />
+            <InlineNumberInput
+              label="Opex %"
+              unit="percent"
+              value={form.operating_expense_rate}
+              onChange={(v) => handleValueChange("operating_expense_rate", v)}
+            />
+            <InlineNumberInput
+              label="Fixed Costs"
+              unit="currency"
+              value={form.fixed_costs}
+              onChange={(v) => handleValueChange("fixed_costs", v)}
+            />
           </div>
         </SidePanel>
         <div className="flex-1 space-y-4">
@@ -339,7 +420,9 @@ export default function Dashboard() {
                 labelTop="Subscriber"
                 labelBottom="LTV"
                 value={metrics.subscriber_ltv}
-                dataArray={projections.mrr.map((v) => v / (form.churn_rate_smb / 100))}
+                dataArray={projections.mrr.map(
+                  (v) => v / (form.churn_rate_smb / 100),
+                )}
                 unit="currency"
                 className="col-span-6 lg:col-span-3"
               />
@@ -348,6 +431,28 @@ export default function Dashboard() {
                 labelBottom="Subscribers"
                 value={metrics.total_subscribers}
                 dataArray={projections.subscribers}
+                className="col-span-6 lg:col-span-3"
+              />
+              <KPIChip
+                labelTop="Blended"
+                labelBottom="CPL"
+                value={metrics.blended_cpl}
+                dataArray={projections.leads.map((l, i) =>
+                  l ? form.marketing_budget / l : 0,
+                )}
+                unit="currency"
+                warning={warning}
+                className="col-span-6 lg:col-span-3"
+              />
+              <KPIChip
+                labelTop="Blended"
+                labelBottom="CVR"
+                value={metrics.blended_cvr}
+                dataArray={projections.leads.map((l, i) =>
+                  l ? (projections.newCustomers[i] / l) * 100 : 0,
+                )}
+                unit="percent"
+                warning={warning}
                 className="col-span-6 lg:col-span-3"
               />
             </div>

--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -1,17 +1,26 @@
-import { useEffect, useRef, useState } from 'react';
-import Sparkline from './Sparkline';
-import { formatNumberShort, formatCurrency } from '../utils/format';
+import { useEffect, useRef, useState } from "react";
+import Sparkline from "./Sparkline";
+import { formatNumberShort, formatCurrency } from "../utils/format";
 
 interface Props {
   labelTop: string;
   labelBottom?: string;
   value: number | string;
   dataArray: number[];
-  unit?: 'currency' | 'percent';
+  unit?: "currency" | "percent";
   className?: string;
+  warning?: boolean;
 }
 
-export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit, className = '' }: Props) {
+export default function KPIChip({
+  labelTop,
+  labelBottom,
+  value,
+  dataArray,
+  unit,
+  className = "",
+  warning = false,
+}: Props) {
   const [refreshing, setRefreshing] = useState(true);
   const prevData = useRef<number[]>([]);
 
@@ -27,24 +36,22 @@ export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit,
   };
 
   const displayValue =
-    typeof value === 'number'
-      ? unit === 'currency'
-        ? '$' + formatCurrency(value)
-        : unit === 'percent'
-        ? value.toFixed(2) + '%'
-        : formatNumberShort(value)
+    typeof value === "number"
+      ? unit === "currency"
+        ? "$" + formatCurrency(value)
+        : unit === "percent"
+          ? value.toFixed(2) + "%"
+          : formatNumberShort(value)
       : value;
 
   const sparkData = [...dataArray];
 
   const trendUp = sparkData[sparkData.length - 1] >= sparkData[0];
-  const sparkColor = trendUp
-    ? 'var(--success-500)'
-    : 'var(--error-500)';
+  const sparkColor = trendUp ? "var(--success-500)" : "var(--error-500)";
 
   return (
     <div
-      className={`kpi-card ${refreshing ? 'refreshing' : ''} ${className}`}
+      className={`kpi-card ${refreshing ? "refreshing" : ""} ${warning ? "warning" : ""} ${className}`}
     >
       <div className="top-row">
         <div className="label-block">
@@ -52,7 +59,9 @@ export default function KPIChip({ labelTop, labelBottom, value, dataArray, unit,
           {labelBottom && <div className="leading-none">{labelBottom}</div>}
         </div>
         <div className="metric">
-          <span className="metric-value" data-unit={unit}>{displayValue}</span>
+          <span className="metric-value" data-unit={unit}>
+            {displayValue}
+          </span>
         </div>
       </div>
       <Sparkline

--- a/frontend/src/model/constants.ts
+++ b/frontend/src/model/constants.ts
@@ -2,15 +2,16 @@ export const DEFAULT_TIER_REVENUES = [500, 1200, 3000, 7500];
 export const DEFAULT_MARKETING_BUDGET = 10000;
 export const DEFAULT_COST_PER_LEAD = 150;
 export const DEFAULT_CONVERSION_RATE = 2.75; // percent
-export const DEFAULT_MONTHLY_CHURN_RATE = 3; // percent
+export const DEFAULT_MONTHLY_CHURN_RATE = 10; // percent
 export const DEFAULT_WACC = 8; // percent
 export const DEFAULT_INITIAL_CAC_SMB = 239;
 export const DEFAULT_PROJECTION_MONTHS = 24;
 export const DEFAULT_INITIAL_INVESTMENT = 200000;
-export const DEFAULT_OPERATING_EXPENSE_RATE = 35;
-export const DEFAULT_FIXED_COSTS = Math.round(50000 / 12);
-export const MONTHLY_WACC = 0.643; // percent
+export const DEFAULT_OPERATING_EXPENSE_RATE = 15;
+export const DEFAULT_FIXED_COSTS = 1500;
+export const MONTHLY_WACC = (0.08 / 12) * 100; // percent
 export const COST_PER_MILLE = 8; // cost per 1000 impressions
+export const DEFAULT_CTR = 1; // percent
 // Default customer mix across pricing tiers, approximating a
 // typical distribution weighted toward lower tiers.
 export const DEFAULT_TIER_ADOPTION = [0.45, 0.3, 0.15, 0.1];

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -31,6 +31,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-neutral-500);font-family:'Roboto Mono',monospace;line-height:1;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
 .kpi-card .top-row{display:flex;justify-content:space-between;align-items:center;}
+.kpi-card.warning .metric-value{color:var(--warning-600);}
 
 /* interactive card */
 .interactive-card>.card-header{all:unset;display:flex;justify-content:space-between;


### PR DESCRIPTION
## Summary
- add helper functions for marketing constants
- tune projection defaults and accept CTR parameter
- extend subscription model with funnel arrays
- validate CPL/CVR inputs and show warning banner
- show blended CPL/CVR KPIs
- add CTR input and advanced marketing notes

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: jest not found)*