### PR TITLE
Refine KPI layout and color tokens

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -26,15 +26,14 @@ Welcome, automated contributor! This project welcomes assistance from AI agents 
 
 ## Dashboard Layout
 
-- KPI cards are arranged in a two-column grid (2x3) with squid-ink backgrounds,
-  pearl labels, and go-green metric text. Sparklines are removed.
-- A Funnel Metrics table below the charts lists Impr, Clicks, Leads, NewCust,
-  BlendedCPL, and BlendedCVR for the first three months.
+- KPI cards appear below the sidebar controls in a two-column grid (2×3).
+- Each card has a `squid-ink` (#131312) background, pearl labels, and Limelight
+  (#95E976) metric text. Sparklines are omitted.
+- Use the `kpiRow` id on the container so CSS can apply the correct flex/grid
+  behavior.
+- Charts follow the KPI section, then the funnel metrics table, and finally the
+  Model Equations list.
+- A Funnel Metrics table lists Impr, Clicks, Leads, NewCust, BlendedCPL, and
+  BlendedCVR for the first three months.
 
 Thank you for your contributions, and happy coding!
-
-## Dashboard Layout
-
-- KPIs appear below the sidebar controls. They are arranged in a 2×3 grid with two cards per row.
-- Each KPI card uses a squid-ink background with pearl labels and go-green metric text. Sparklines are omitted.
-- Charts follow the KPI section, and the Model Equations list sits beneath the charts.

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -402,14 +402,13 @@ export default function Dashboard() {
           {metrics && (
             <>
               <h3 className="content-header">Key Metrics</h3>
-              <div className="grid grid-cols-12 gap-4 mb-4">
+              <div id="kpiRow" className="mb-4">
                 <KPIChip
                   labelTop="Total"
                   labelBottom="MRR"
                   value={metrics.total_mrr}
                   dataArray={projections.mrr}
                   unit="currency"
-                  className="col-span-6 lg:col-span-3"
                 />
                 <KPIChip
                   labelTop="Annual"
@@ -417,7 +416,6 @@ export default function Dashboard() {
                   value={metrics.annual_revenue}
                   dataArray={projections.mrr.map((v) => v * 12)}
                   unit="currency"
-                  className="col-span-6 lg:col-span-3"
                 />
                 <KPIChip
                   labelTop="Subscriber"
@@ -427,14 +425,12 @@ export default function Dashboard() {
                     (v) => v / (form.churn_rate_smb / 100),
                   )}
                   unit="currency"
-                  className="col-span-6 lg:col-span-3"
                 />
                 <KPIChip
                   labelTop="Total"
                   labelBottom="Subscribers"
                   value={metrics.total_subscribers}
                   dataArray={projections.subscribers}
-                  className="col-span-6 lg:col-span-3"
                 />
                 <KPIChip
                   labelTop="Blended"
@@ -445,7 +441,6 @@ export default function Dashboard() {
                   )}
                   unit="currency"
                   warning={warning}
-                  className="col-span-6 lg:col-span-3"
                 />
                 <KPIChip
                   labelTop="Blended"
@@ -456,7 +451,6 @@ export default function Dashboard() {
                   )}
                   unit="percent"
                   warning={warning}
-                  className="col-span-6 lg:col-span-3"
                 />
               </div>
             </>

--- a/frontend/src/components/EquationReport.tsx
+++ b/frontend/src/components/EquationReport.tsx
@@ -5,30 +5,57 @@ export default function EquationReport() {
     <div>
       <h3 className="content-header">Model Equations</h3>
       <Card>
-        <ul className="text-sm list-disc pl-6 space-y-1 font-mono">
+        <ul className="text-sm leading-snug list-disc pl-6 space-y-2 font-mono">
           <li>
-            Impressions = (Marketing Budget / Cost per 1K Impressions) × 1000
+            <span className="font-semibold">Impressions</span> = (Marketing
+            Budget / Cost per 1K Impressions) × 1000
           </li>
-          <li>Clicks = Impressions × CTR</li>
-          <li>Leads = Marketing Budget / Cost Per Lead</li>
-          <li>New Customers = Leads × Conversion Rate</li>
-          <li>Churned Customers = Customers × Churn Rate</li>
           <li>
-            Customers Next Month = Customers + New Customers − Churned Customers
+            <span className="font-semibold">Clicks</span> = Impressions × CTR
           </li>
-          <li>MRR = Customers × Average Revenue Per Customer</li>
           <li>
-            Subscriber LTV = [Average Revenue Per Customer × (1 − Operating
-            Expense %)] / Churn Rate
+            <span className="font-semibold">Leads</span> = Marketing Budget /
+            Cost Per Lead
           </li>
-          <li>Gross Profit = MRR × (1 − Operating Expense %)</li>
           <li>
-            Monthly Cash Flow = Gross Profit − Fixed Costs − Marketing Spend
+            <span className="font-semibold">New Customers</span> = Leads ×
+            Conversion Rate
           </li>
-          <li>Blended CPL = Marketing Budget / Leads</li>
-          <li>Blended CVR = (New Customers / Leads) × 100</li>
           <li>
-            NPV = ∑ Cash Flow / (1 + WACC / 12)<sup>n</sup> − Initial Investment
+            <span className="font-semibold">Churned Customers</span> = Customers
+            × Churn Rate
+          </li>
+          <li>
+            <span className="font-semibold">Customers Next Month</span> =
+            Customers + New Customers − Churned Customers
+          </li>
+          <li>
+            <span className="font-semibold">MRR</span> = Customers × Average
+            Revenue Per Customer
+          </li>
+          <li>
+            <span className="font-semibold">Subscriber LTV</span> = [Average
+            Revenue Per Customer × (1 − Operating Expense %)] / Churn Rate
+          </li>
+          <li>
+            <span className="font-semibold">Gross Profit</span> = MRR × (1 −
+            Operating Expense %)
+          </li>
+          <li>
+            <span className="font-semibold">Monthly Cash Flow</span> = Gross
+            Profit − Fixed Costs − Marketing Spend
+          </li>
+          <li>
+            <span className="font-semibold">Blended CPL</span> = Marketing
+            Budget / Leads
+          </li>
+          <li>
+            <span className="font-semibold">Blended CVR</span> = (New Customers
+            / Leads) × 100
+          </li>
+          <li>
+            <span className="font-semibold">NPV</span> = ∑ Cash Flow / (1 + WACC
+            / 12)<sup>n</sup> − Initial Investment
           </li>
         </ul>
       </Card>

--- a/frontend/src/styles/brand-tokens.css
+++ b/frontend/src/styles/brand-tokens.css
@@ -2,123 +2,124 @@
 
 /* Primary Colors */
 :root {
-  --color-squid-ink: #101010;
-  --color-pearl: #F2F2F0;
+  --color-squid-ink: #131312;
+  --color-pearl: #f2f2f0;
+  --color-limelight: #95e976;
 }
 
 /* Gradients */
 :root {
-  --gradient-catona-logo-dark: #3461EA;
-  --gradient-catona-logo-light: #5B50B8;
-  --gradient-nightfall-dark: #5956E2;
-  --gradient-nightfall-middle: #A46BD0;
-  --gradient-nightfall-light: #DE9CB9;
-  --gradient-dawn-dark: #B271C0;
-  --gradient-dawn-light: #DEC4BC;
-  --gradient-aurora-dark: #50E89C;
-  --gradient-aurora-light: #92F4B4;
+  --gradient-catona-logo-dark: #3461ea;
+  --gradient-catona-logo-light: #5b50b8;
+  --gradient-nightfall-dark: #5956e2;
+  --gradient-nightfall-middle: #a46bd0;
+  --gradient-nightfall-light: #de9cb9;
+  --gradient-dawn-dark: #b271c0;
+  --gradient-dawn-light: #dec4bc;
+  --gradient-aurora-dark: #50e89c;
+  --gradient-aurora-light: #92f4b4;
 }
 
 /* Neutral Colors */
 :root {
   --color-thunder-300: #898989;
-  --color-driftwood-200: #C9C9C9;
+  --color-driftwood-200: #c9c9c9;
 
   --color-neutral-950: #131312;
-  --color-neutral-900: #1E1D1B;
+  --color-neutral-900: #1e1d1b;
   --color-neutral-800: #292929;
   --color-neutral-700: #393437;
   --color-neutral-600: #555654;
   --color-neutral-500: #747370;
-  --color-neutral-400: #91918D;
-  --color-neutral-300: #ADACA9;
-  --color-neutral-200: #CAC9C5;
-  --color-neutral-150: #E3E2E0;
-  --color-neutral-100: #F5F3F0;
-  --color-neutral-50: #FDFCFA;
+  --color-neutral-400: #91918d;
+  --color-neutral-300: #adaca9;
+  --color-neutral-200: #cac9c5;
+  --color-neutral-150: #e3e2e0;
+  --color-neutral-100: #f5f3f0;
+  --color-neutral-50: #fdfcfa;
 }
 
 /* Accents */
 :root {
   --accent-primary-900: #210063;
-  --accent-primary-800: #2A087D;
-  --accent-primary-700: #35329C;
-  --accent-primary-600: #3F3CBB;
-  --accent-primary-500: #4A47DC;
-  --accent-primary-400: #8688E3;
-  --accent-primary-300: #BDB8EB;
-  --accent-primary-200: #D1D9F0;
-  --accent-primary-100: #E3E3F7;
-  --accent-primary-50: #EDEDFC;
+  --accent-primary-800: #2a087d;
+  --accent-primary-700: #35329c;
+  --accent-primary-600: #3f3cbb;
+  --accent-primary-500: #4a47dc;
+  --accent-primary-400: #8688e3;
+  --accent-primary-300: #bdb8eb;
+  --accent-primary-200: #d1d9f0;
+  --accent-primary-100: #e3e3f7;
+  --accent-primary-50: #ededfc;
 
   --accent-secondary-900: #503858;
-  --accent-secondary-800: #6D477D;
-  --accent-secondary-700: #885B98;
-  --accent-secondary-600: #A242A7;
-  --accent-secondary-500: #BF7DCA;
-  --accent-secondary-400: #D8B6DF;
-  --accent-secondary-300: #E7D4EA;
-  --accent-secondary-200: #EDD7F0;
-  --accent-secondary-100: #F0E6F1;
-  --accent-secondary-50: #F6F3F9;
+  --accent-secondary-800: #6d477d;
+  --accent-secondary-700: #885b98;
+  --accent-secondary-600: #a242a7;
+  --accent-secondary-500: #bf7dca;
+  --accent-secondary-400: #d8b6df;
+  --accent-secondary-300: #e7d4ea;
+  --accent-secondary-200: #edd7f0;
+  --accent-secondary-100: #f0e6f1;
+  --accent-secondary-50: #f6f3f9;
 }
 
 /* Semantic Colors */
 
 /* Error */
 :root {
-  --error-900: #641B20;
-  --error-800: #7F2933;
-  --error-700: #BE2840;
-  --error-600: #D83440;
-  --error-500: #E43D4A;
-  --error-400: #E46078;
-  --error-300: #EA859F;
-  --error-200: #F1ACBB;
-  --error-100: #F7D6D7;
-  --error-50: #FCECEF;
+  --error-900: #641b20;
+  --error-800: #7f2933;
+  --error-700: #be2840;
+  --error-600: #d83440;
+  --error-500: #e43d4a;
+  --error-400: #e46078;
+  --error-300: #ea859f;
+  --error-200: #f1acbb;
+  --error-100: #f7d6d7;
+  --error-50: #fcecef;
 }
 
 /* Warning */
 :root {
   --warning-900: #716405;
-  --warning-800: #8E7E26;
-  --warning-700: #BE9F2F;
-  --warning-600: #D4AA16;
-  --warning-500: #F9CB3A;
-  --warning-400: #FAC283;
-  --warning-300: #F8D9CF;
-  --warning-200: #F7E0B9;
-  --warning-100: #FEF2C8;
-  --warning-50: #FEFAE8;
+  --warning-800: #8e7e26;
+  --warning-700: #be9f2f;
+  --warning-600: #d4aa16;
+  --warning-500: #f9cb3a;
+  --warning-400: #fac283;
+  --warning-300: #f8d9cf;
+  --warning-200: #f7e0b9;
+  --warning-100: #fef2c8;
+  --warning-50: #fefae8;
 }
 
 /* Success */
 :root {
-  --success-900: #436D35;
+  --success-900: #436d35;
   --success-800: #558843;
-  --success-700: #83A554;
-  --success-600: #7FC964;
-  --success-500: #91E876;
-  --success-400: #ABED9F;
-  --success-300: #BCF1A9;
-  --success-200: #D9F6C4;
-  --success-100: #EAF4D8;
-  --success-50: #F4F8E1;
+  --success-700: #83a554;
+  --success-600: #7fc964;
+  --success-500: var(--color-limelight);
+  --success-400: #abed9f;
+  --success-300: #bcf1a9;
+  --success-200: #d9f6c4;
+  --success-100: #eaf4d8;
+  --success-50: #f4f8e1;
 }
 
 /* Information */
 :root {
-  --information-900: #2F5461;
-  --information-800: #336E74;
-  --information-700: #508EA4;
-  --information-600: #7EBDE2;
-  --information-500: #74CBF7;
-  --information-400: #9DD8EC;
-  --information-300: #A0DAEF;
-  --information-200: #E8F5FB;
-  --information-100: #ECF6FD;
-  --information-50: #F6FBFE;
+  --information-900: #2f5461;
+  --information-800: #336e74;
+  --information-700: #508ea4;
+  --information-600: #7ebde2;
+  --information-500: #74cbf7;
+  --information-400: #9dd8ec;
+  --information-300: #a0daef;
+  --information-200: #e8f5fb;
+  --information-100: #ecf6fd;
+  --information-50: #f6fbfe;
 }
 
 /* Legacy aliases for existing styles */
@@ -129,7 +130,7 @@
   --cat-grad-a: var(--accent-primary-500);
   --cat-grad-b: var(--accent-secondary-500);
   --cat-grad-c: var(--gradient-dawn-dark);
-  --cat-green: var(--success-500);
+  --cat-green: var(--color-limelight);
   --cat-blue: var(--information-500);
   --cat-success: var(--success-500);
   --cat-error: var(--error-500);
@@ -152,9 +153,9 @@
   --radius-md: 8px;
   --radius-pill: 9999px;
 
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
-  --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
-  --shadow-lg: 0 10px 15px rgba(0,0,0,0.15);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.15);
   --shadow-focus: 0 0 0 2px var(--accent-primary-500);
 
   --z-sticky: 1000;
@@ -162,8 +163,16 @@
   --transition-fast: 0.15s;
   --transition-normal: 0.3s;
 
-  --catona-gradient: linear-gradient(90deg,var(--gradient-catona-logo-dark),var(--gradient-catona-logo-light));
-  --nightfall-gradient: linear-gradient(90deg,var(--gradient-nightfall-dark),var(--gradient-nightfall-light));
+  --catona-gradient: linear-gradient(
+    90deg,
+    var(--gradient-catona-logo-dark),
+    var(--gradient-catona-logo-light)
+  );
+  --nightfall-gradient: linear-gradient(
+    90deg,
+    var(--gradient-nightfall-dark),
+    var(--gradient-nightfall-light)
+  );
 }
 
 /* Legacy color aliases */

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -30,7 +30,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .kpi-card{position:relative;background:var(--squid-ink);border-radius:8px;padding:var(--space-sm) var(--space-md);overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;box-shadow:0px -2px 2px 0px rgba(0,0,0,0.02) inset,0px 1.873px 23.41px 0px rgba(0,0,0,0.04);min-height:72px;}
 .kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-pearl);font-family:'Roboto Mono',monospace;line-height:1;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;}
-.kpi-card .metric-value{font-size:1.5rem;color:var(--success-500);}
+.kpi-card .metric-value{font-size:1.5rem;color:var(--color-limelight);}
 .kpi-card .top-row{display:flex;justify-content:space-between;align-items:center;}
 .kpi-card.warning .metric-value{color:var(--warning-600);}
 
@@ -52,7 +52,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
     overflow-x:auto; /* Enable horizontal scrolling */
     padding-bottom:var(--space-sm); /* Space for scrollbar if it appears */
     /* Prevent flex items from shrinking too much */
-    & > .metric-card {
+    & > .kpi-card {
         flex: 0 0 auto; /* Don't grow, don't shrink, auto basis */
         width: 220px; /* Fixed width for scrollable items */
     }
@@ -60,10 +60,10 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 @media(min-width:1024px){ /* lg breakpoint */
     #kpiRow{
         display:grid;
-        grid-template-columns:repeat(5,1fr); /* 5 columns on large screens */
+        grid-template-columns:repeat(2,1fr); /* two columns on large screens */
         overflow-x:visible; /* Disable horizontal scrolling */
         padding-bottom: 0;
-        & > .metric-card {
+        & > .kpi-card {
            width: auto; /* Reset width for grid layout */
         }
     }

--- a/static/css/brand-tokens.css
+++ b/static/css/brand-tokens.css
@@ -2,123 +2,124 @@
 
 /* Primary Colors */
 :root {
-  --color-squid-ink: #101010;
-  --color-pearl: #F2F2F0;
+  --color-squid-ink: #131312;
+  --color-pearl: #f2f2f0;
+  --color-limelight: #95e976;
 }
 
 /* Gradients */
 :root {
-  --gradient-catona-logo-dark: #3461EA;
-  --gradient-catona-logo-light: #5B50B8;
-  --gradient-nightfall-dark: #5956E2;
-  --gradient-nightfall-middle: #A46BD0;
-  --gradient-nightfall-light: #DE9CB9;
-  --gradient-dawn-dark: #B271C0;
-  --gradient-dawn-light: #DEC4BC;
-  --gradient-aurora-dark: #50E89C;
-  --gradient-aurora-light: #92F4B4;
+  --gradient-catona-logo-dark: #3461ea;
+  --gradient-catona-logo-light: #5b50b8;
+  --gradient-nightfall-dark: #5956e2;
+  --gradient-nightfall-middle: #a46bd0;
+  --gradient-nightfall-light: #de9cb9;
+  --gradient-dawn-dark: #b271c0;
+  --gradient-dawn-light: #dec4bc;
+  --gradient-aurora-dark: #50e89c;
+  --gradient-aurora-light: #92f4b4;
 }
 
 /* Neutral Colors */
 :root {
   --color-thunder-300: #898989;
-  --color-driftwood-200: #C9C9C9;
+  --color-driftwood-200: #c9c9c9;
 
   --color-neutral-950: #131312;
-  --color-neutral-900: #1E1D1B;
+  --color-neutral-900: #1e1d1b;
   --color-neutral-800: #292929;
   --color-neutral-700: #393437;
   --color-neutral-600: #555654;
   --color-neutral-500: #747370;
-  --color-neutral-400: #91918D;
-  --color-neutral-300: #ADACA9;
-  --color-neutral-200: #CAC9C5;
-  --color-neutral-150: #E3E2E0;
-  --color-neutral-100: #F5F3F0;
-  --color-neutral-50: #FDFCFA;
+  --color-neutral-400: #91918d;
+  --color-neutral-300: #adaca9;
+  --color-neutral-200: #cac9c5;
+  --color-neutral-150: #e3e2e0;
+  --color-neutral-100: #f5f3f0;
+  --color-neutral-50: #fdfcfa;
 }
 
 /* Accents */
 :root {
   --accent-primary-900: #210063;
-  --accent-primary-800: #2A087D;
-  --accent-primary-700: #35329C;
-  --accent-primary-600: #3F3CBB;
-  --accent-primary-500: #4A47DC;
-  --accent-primary-400: #8688E3;
-  --accent-primary-300: #BDB8EB;
-  --accent-primary-200: #D1D9F0;
-  --accent-primary-100: #E3E3F7;
-  --accent-primary-50: #EDEDFC;
+  --accent-primary-800: #2a087d;
+  --accent-primary-700: #35329c;
+  --accent-primary-600: #3f3cbb;
+  --accent-primary-500: #4a47dc;
+  --accent-primary-400: #8688e3;
+  --accent-primary-300: #bdb8eb;
+  --accent-primary-200: #d1d9f0;
+  --accent-primary-100: #e3e3f7;
+  --accent-primary-50: #ededfc;
 
   --accent-secondary-900: #503858;
-  --accent-secondary-800: #6D477D;
-  --accent-secondary-700: #885B98;
-  --accent-secondary-600: #A242A7;
-  --accent-secondary-500: #BF7DCA;
-  --accent-secondary-400: #D8B6DF;
-  --accent-secondary-300: #E7D4EA;
-  --accent-secondary-200: #EDD7F0;
-  --accent-secondary-100: #F0E6F1;
-  --accent-secondary-50: #F6F3F9;
+  --accent-secondary-800: #6d477d;
+  --accent-secondary-700: #885b98;
+  --accent-secondary-600: #a242a7;
+  --accent-secondary-500: #bf7dca;
+  --accent-secondary-400: #d8b6df;
+  --accent-secondary-300: #e7d4ea;
+  --accent-secondary-200: #edd7f0;
+  --accent-secondary-100: #f0e6f1;
+  --accent-secondary-50: #f6f3f9;
 }
 
 /* Semantic Colors */
 
 /* Error */
 :root {
-  --error-900: #641B20;
-  --error-800: #7F2933;
-  --error-700: #BE2840;
-  --error-600: #D83440;
-  --error-500: #E43D4A;
-  --error-400: #E46078;
-  --error-300: #EA859F;
-  --error-200: #F1ACBB;
-  --error-100: #F7D6D7;
-  --error-50: #FCECEF;
+  --error-900: #641b20;
+  --error-800: #7f2933;
+  --error-700: #be2840;
+  --error-600: #d83440;
+  --error-500: #e43d4a;
+  --error-400: #e46078;
+  --error-300: #ea859f;
+  --error-200: #f1acbb;
+  --error-100: #f7d6d7;
+  --error-50: #fcecef;
 }
 
 /* Warning */
 :root {
   --warning-900: #716405;
-  --warning-800: #8E7E26;
-  --warning-700: #BE9F2F;
-  --warning-600: #D4AA16;
-  --warning-500: #F9CB3A;
-  --warning-400: #FAC283;
-  --warning-300: #F8D9CF;
-  --warning-200: #F7E0B9;
-  --warning-100: #FEF2C8;
-  --warning-50: #FEFAE8;
+  --warning-800: #8e7e26;
+  --warning-700: #be9f2f;
+  --warning-600: #d4aa16;
+  --warning-500: #f9cb3a;
+  --warning-400: #fac283;
+  --warning-300: #f8d9cf;
+  --warning-200: #f7e0b9;
+  --warning-100: #fef2c8;
+  --warning-50: #fefae8;
 }
 
 /* Success */
 :root {
-  --success-900: #436D35;
+  --success-900: #436d35;
   --success-800: #558843;
-  --success-700: #83A554;
-  --success-600: #7FC964;
-  --success-500: #91E876;
-  --success-400: #ABED9F;
-  --success-300: #BCF1A9;
-  --success-200: #D9F6C4;
-  --success-100: #EAF4D8;
-  --success-50: #F4F8E1;
+  --success-700: #83a554;
+  --success-600: #7fc964;
+  --success-500: var(--color-limelight);
+  --success-400: #abed9f;
+  --success-300: #bcf1a9;
+  --success-200: #d9f6c4;
+  --success-100: #eaf4d8;
+  --success-50: #f4f8e1;
 }
 
 /* Information */
 :root {
-  --information-900: #2F5461;
-  --information-800: #336E74;
-  --information-700: #508EA4;
-  --information-600: #7EBDE2;
-  --information-500: #74CBF7;
-  --information-400: #9DD8EC;
-  --information-300: #A0DAEF;
-  --information-200: #E8F5FB;
-  --information-100: #ECF6FD;
-  --information-50: #F6FBFE;
+  --information-900: #2f5461;
+  --information-800: #336e74;
+  --information-700: #508ea4;
+  --information-600: #7ebde2;
+  --information-500: #74cbf7;
+  --information-400: #9dd8ec;
+  --information-300: #a0daef;
+  --information-200: #e8f5fb;
+  --information-100: #ecf6fd;
+  --information-50: #f6fbfe;
 }
 
 /* Legacy aliases for existing styles */
@@ -129,7 +130,7 @@
   --cat-grad-a: var(--accent-primary-500);
   --cat-grad-b: var(--accent-secondary-500);
   --cat-grad-c: var(--gradient-dawn-dark);
-  --cat-green: var(--success-500);
+  --cat-green: var(--color-limelight);
   --cat-blue: var(--information-500);
   --cat-success: var(--success-500);
   --cat-error: var(--error-500);
@@ -152,9 +153,9 @@
   --radius-md: 8px;
   --radius-pill: 9999px;
 
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
-  --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
-  --shadow-lg: 0 10px 15px rgba(0,0,0,0.15);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.15);
   --shadow-focus: 0 0 0 2px var(--accent-primary-500);
 
   --z-sticky: 1000;
@@ -162,8 +163,16 @@
   --transition-fast: 0.15s;
   --transition-normal: 0.3s;
 
-  --catona-gradient: linear-gradient(90deg,var(--gradient-catona-logo-dark),var(--gradient-catona-logo-light));
-  --nightfall-gradient: linear-gradient(90deg,var(--gradient-nightfall-dark),var(--gradient-nightfall-light));
+  --catona-gradient: linear-gradient(
+    90deg,
+    var(--gradient-catona-logo-dark),
+    var(--gradient-catona-logo-light)
+  );
+  --nightfall-gradient: linear-gradient(
+    90deg,
+    var(--gradient-nightfall-dark),
+    var(--gradient-nightfall-light)
+  );
 }
 
 /* Legacy color aliases */

--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -20,9 +20,10 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .metric-label{font-size:0.875rem; color: #4c5d70; /* Neutral-700 like */}
 
 /* KPI chips */
-.kpi-card{position:relative;background:var(--neutral-50);border-radius:8px;padding:1rem;overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;box-shadow:0px -2px 2px 0px rgba(0,0,0,0.02) inset,0px 1.873px 23.41px 0px rgba(0,0,0,0.04);height:80px;}
-.kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-neutral-500);font-family:'Roboto Mono',monospace;}
+.kpi-card{position:relative;background:var(--squid-ink);border-radius:8px;padding:1rem;overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;box-shadow:0px -2px 2px 0px rgba(0,0,0,0.02) inset,0px 1.873px 23.41px 0px rgba(0,0,0,0.04);height:80px;}
+.kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-pearl);font-family:'Roboto Mono',monospace;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
+.kpi-card .metric-value{color:var(--color-limelight);}
 .kpi-card .top-row{display:flex;justify-content:space-between;align-items:flex-end;}
 .sparkline{display:block;width:100%;height:32px!important;pointer-events:none;clip-path:inset(0 round 8px);}
 
@@ -44,7 +45,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
     overflow-x:auto; /* Enable horizontal scrolling */
     padding-bottom:var(--space-sm); /* Space for scrollbar if it appears */
     /* Prevent flex items from shrinking too much */
-    & > .metric-card {
+    & > .kpi-card {
         flex: 0 0 auto; /* Don't grow, don't shrink, auto basis */
         width: 220px; /* Fixed width for scrollable items */
     }
@@ -52,10 +53,10 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 @media(min-width:1024px){ /* lg breakpoint */
     #kpiRow{
         display:grid;
-        grid-template-columns:repeat(5,1fr); /* 5 columns on large screens */
+        grid-template-columns:repeat(2,1fr); /* two columns on large screens */
         overflow-x:visible; /* Disable horizontal scrolling */
         padding-bottom: 0;
-        & > .metric-card {
+        & > .kpi-card {
            width: auto; /* Reset width for grid layout */
         }
     }


### PR DESCRIPTION
## Summary
- update brand tokens with limelight and new squid-ink shade
- style KPI cards with new colors and adjust grid
- widen KPI layout by using `kpiRow` grid with two columns
- improve Model Equations typography
- refresh AGENT guidelines

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: jest not found)*