### PR TITLE
Add carbon inputs and metrics

### DIFF
--- a/frontend/src/model/constants.ts
+++ b/frontend/src/model/constants.ts
@@ -19,3 +19,6 @@ export const DEFAULT_TIER_ADOPTION = [0.45, 0.3, 0.15, 0.1];
 export const TIER_CPL_FACTORS = [1, 1.6, 2.5, 4];
 export const TIER_CVR_FACTORS = [1, 0.65, 0.35, 0.15];
 export const TIER_BUDGET_SPLIT = [0.4, 0.3, 0.2, 0.1];
+
+export const DEFAULT_COST_OF_CARBON = 18;
+export const DEFAULT_TONS_PER_CUSTOMER = [10, 25, 70, 200];

--- a/frontend/src/model/finance.ts
+++ b/frontend/src/model/finance.ts
@@ -1,4 +1,4 @@
-import { SubscriptionResult } from './subscription';
+import { SubscriptionResult } from "./subscription";
 
 export interface Expenses {
   operatingExpenseRate: number;
@@ -13,17 +13,9 @@ export function calculateFinancialMetrics(
   modelResults: SubscriptionResult,
   initialInvestment: number,
   expenses: Expenses,
-  wacc: number
+  wacc: number,
 ) {
-  const grossProfits = modelResults.projections.mrr_by_month.map((mrr) => {
-    return mrr * (1 - expenses.operatingExpenseRate / 100);
-  });
-
-  const monthlyMarketing = expenses.marketingSpend || 0;
-
-  const cashFlows = grossProfits.map((gp) => {
-    return gp - expenses.fixedCosts - monthlyMarketing;
-  });
+  const cashFlows = modelResults.projections.free_cash_flow;
 
   const waccMonthly = Math.pow(1 + wacc / 100, 1 / 12) - 1;
 
@@ -35,7 +27,10 @@ export function calculateFinancialMetrics(
   let paybackMonths: number | null = null;
   for (let i = 0; i < cashFlows.length; i++) {
     cumulative += cashFlows[i];
-    if (cumulative > 0) { paybackMonths = i + 1; break; }
+    if (cumulative > 0) {
+      paybackMonths = i + 1;
+      break;
+    }
   }
 
   return { npv, paybackMonths, cashFlows };

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -111,21 +111,13 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
   color:var(--squid-ink);
   font-family:'Inter',sans-serif;
 }
-.sub-header{
-  font-size:18px;
-  font-weight:500;
-  line-height:110%;
-  letter-spacing:-0.04em;
-  color:var(--neutral-400);
-  font-family:'Roboto Mono',monospace;
-}
+.sub-header,
 .content-header{
-  font-size:18px;
-  font-weight:700;
-  line-height:110%;
-  letter-spacing:-0.02em;
-  color:var(--squid-ink);
-  font-family:'Inter',sans-serif;
+  font-family:'Roboto Mono',monospace;
+  font-size:0.875rem;
+  font-weight:500;
+  line-height:1.4;
+  color:var(--color-neutral-500);
   margin-bottom:1rem;
 }
 .sidebar-title{


### PR DESCRIPTION
## Summary
- unify header styles with sidebar look
- support carbon economics in constants and model calculations
- compute carbon cost in the subscription model and return new metrics
- add carbon cost inputs and KPI chips to the dashboard
- adjust financial calculation to use new cash flows

## Testing
- `python -m pytest` *(fails: No module named pytest)*
- `npm test` *(fails: jest not found)*