### PR TITLE
Remove blended ton KPI and refine equations

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -62,7 +62,7 @@ interface Metrics {
   paybackMonths: number | null;
   blended_cvr: number;
   blended_cpl: number;
-  carbon_delivered: number;
+  carbon_ordered: number;
   carbon_spend_pct: number;
   blended_usd_per_ton: number;
   margin_warning: boolean;
@@ -178,12 +178,12 @@ export default function Dashboard() {
       total_mrr: results.metrics.total_mrr,
       annual_revenue: results.metrics.annual_revenue,
       subscriber_ltv: results.metrics.subscriber_ltv,
-      total_subscribers: results.metrics.total_subscribers,
+      total_subscribers: Math.round(results.metrics.total_subscribers),
       npv: financial.npv,
       paybackMonths: financial.paybackMonths,
       blended_cvr: blendedCvr,
       blended_cpl: blendedCpl,
-      carbon_delivered: results.metrics.carbon_delivered,
+      carbon_ordered: results.metrics.carbon_ordered,
       carbon_spend_pct: results.metrics.carbon_spend_pct,
       blended_usd_per_ton: results.metrics.blended_usd_per_ton,
       margin_warning: results.metrics.margin_warning,
@@ -191,7 +191,7 @@ export default function Dashboard() {
 
     const labels = results.projections.monthLabels;
     const mrrArr = results.projections.mrr_by_month;
-    const subArr = results.projections.customers_by_month;
+    const subArr = results.projections.customers_by_month.map(Math.round);
     const tierArr = results.projections.tier_revenue_by_month;
     const tierPrices = results.projections.tier_revenues_end;
     const tierCustomers = tierArr.map((arr, idx) =>
@@ -203,7 +203,7 @@ export default function Dashboard() {
       impressions: results.projections.impressions_by_month,
       clicks: results.projections.clicks_by_month,
       leads: results.projections.leads_by_month,
-      newCustomers: results.projections.new_customers_by_month,
+      newCustomers: results.projections.new_customers_by_month.map(Math.round),
       carbonTons: results.projections.carbon_tons_by_month,
       carbonCost: results.projections.carbon_cost_by_month,
     });
@@ -219,17 +219,6 @@ export default function Dashboard() {
             borderColor: mrrColor,
             borderWidth: 4,
             yAxisID: "y1",
-            pointRadius: 0,
-            pointHoverRadius: 4,
-          },
-          {
-            label: "Carbon Delivered",
-            data: results.projections.carbon_tons_by_month,
-            borderColor: "#95E976",
-            backgroundColor: "rgba(149,233,118,0.3)",
-            borderWidth: 2,
-            yAxisID: "y2",
-            fill: true,
             pointRadius: 0,
             pointHoverRadius: 4,
           },
@@ -255,12 +244,14 @@ export default function Dashboard() {
                 x: { grid: { display: false } },
                 y1: {
                   position: "left",
+                  min: 1,
                   ticks: {
                     callback: (v: any) => "$" + formatCurrency(Number(v)),
                   },
                 },
                 y2: {
                   position: "right",
+                  min: 1,
                   grid: { drawOnChartArea: false },
                   ticks: {
                     callback: (v: any) => Number(v).toLocaleString(),
@@ -301,6 +292,7 @@ export default function Dashboard() {
                 x: { stacked: true, grid: { display: false } },
                 y: {
                   stacked: true,
+                  min: 1,
                   ticks: {
                     callback: (v: any) => "$" + formatCurrency(Number(v)),
                   },
@@ -348,7 +340,7 @@ export default function Dashboard() {
         </div>
       )}
       <div className="lg:flex gap-4">
-        <SidePanel className="side-panel sticky top-4 lg:w-[260px] w-full max-h-[calc(100vh-140px)] overflow-y-auto">
+        <SidePanel className="side-panel sticky top-4 lg:w-[260px] w-full max-h-[calc(100vh-100px)] overflow-y-auto">
           <div className="space-y-3 mb-6">
             <h3 className="sidebar-title mb-2">Pricing Tiers</h3>
             {[1, 2, 3, 4].map((n) => (
@@ -520,7 +512,7 @@ export default function Dashboard() {
                 <KPIChip
                   labelTop="Carbon"
                   labelBottom="t/mo"
-                  value={metrics.carbon_delivered}
+                  value={metrics.carbon_ordered}
                   dataArray={projections.carbonTons}
                 />
                 <KPIChip
@@ -531,15 +523,6 @@ export default function Dashboard() {
                     projections.mrr[i] ? (c / projections.mrr[i]) * 100 : 0,
                   )}
                   unit="percent"
-                />
-                <KPIChip
-                  labelTop="Blended $/t"
-                  value={metrics.blended_usd_per_ton}
-                  dataArray={projections.carbonTons.map((t, i) =>
-                    t ? projections.carbonCost[i] / t : 0,
-                  )}
-                  unit="currency"
-                  warning={metrics.margin_warning}
                 />
               </div>
             </>

--- a/frontend/src/components/EquationReport.tsx
+++ b/frontend/src/components/EquationReport.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Card from "./Card";
 
 interface Metrics {
@@ -34,6 +35,7 @@ interface Props {
 }
 
 export default function EquationReport({ form, metrics, projections }: Props) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
   const impressions = projections.impressions[0] || 0;
   const clicks = projections.clicks[0] || 0;
   const leads = projections.leads[0] || 0;
@@ -53,58 +55,79 @@ export default function EquationReport({ form, metrics, projections }: Props) {
       label: "Impressions",
       value: impressions,
       text: "(Marketing Budget / Cost per 1K Impressions) × 1000",
+      code: "const impressions = (marketingBudget / COST_PER_MILLE) * 1000;",
     },
-    { label: "Clicks", value: clicks, text: "Impressions × CTR" },
-    { label: "Leads", value: leads, text: "Marketing Budget / Cost Per Lead" },
+    {
+      label: "Clicks",
+      value: clicks,
+      text: "Impressions × CTR",
+      code: "const clicks = impressions * (ctr / 100);",
+    },
+    {
+      label: "Leads",
+      value: leads,
+      text: "Marketing Budget / Cost Per Lead",
+      code: "const leads = marketingBudget / costPerLead;",
+    },
     {
       label: "New Customers",
       value: newCustomers,
       text: "Leads × Conversion Rate",
+      code: "const newCustomers = leads * (conversionRate / 100);",
     },
     {
       label: "Churned Customers",
       value: churned,
       text: "Customers × Churn Rate",
+      code: "const churned = customers * (churnRate / 100);",
     },
     {
       label: "Customers Next Month",
       value: customersNext,
       text: "Customers + New Customers − Churned Customers",
+      code: "const next = customers + newCustomers - churned;",
     },
     {
       label: "MRR",
       value: mrr,
       text: "Customers × Average Revenue Per Customer",
+      code: "const mrr = customers * arpc;",
     },
     {
       label: "Subscriber LTV",
       value: subscriberLtv,
       text: "[Average Revenue Per Customer × (1 − Operating Expense %)] / Churn Rate",
+      code: "const ltv = (arpc * (1 - opexRate/100)) / churnRate;",
     },
     {
       label: "Gross Profit",
       value: grossProfit,
       text: "MRR × (1 − Operating Expense %)",
+      code: "const grossProfit = mrr * (1 - opexRate/100);",
     },
     {
       label: "Monthly Cash Flow",
       value: monthlyCash,
       text: "Gross Profit − Fixed Costs − Marketing Spend",
+      code: "const cash = grossProfit - fixedCosts - marketingBudget;",
     },
     {
       label: "Blended CPL",
       value: blendedCpl,
       text: "Marketing Budget / Leads",
+      code: "const blendedCpl = marketingBudget / leads;",
     },
     {
       label: "Blended CVR",
       value: blendedCvr,
       text: "(New Customers / Leads) × 100",
+      code: "const blendedCvr = (newCustomers / leads) * 100;",
     },
     {
       label: "NPV",
       value: npv,
       text: "∑ Cash Flow / (1 + WACC / 12)^n − Initial Investment",
+      code: "const npv = sum(cashFlow / (1 + wacc/12)**n) - initialInvestment;",
     },
   ];
 
@@ -114,18 +137,32 @@ export default function EquationReport({ form, metrics, projections }: Props) {
       <Card>
         <table className="w-full text-xs font-mono">
           <tbody>
-            {rows.map((row) => (
-              <tr key={row.label} className="align-top">
-                <td className="pr-2 text-right whitespace-nowrap">
-                  {row.value.toLocaleString(undefined, {
-                    maximumFractionDigits: 2,
-                  })}
-                </td>
-                <td>
-                  <span className="font-semibold">{row.label}</span> ={" "}
-                  {row.text}
-                </td>
-              </tr>
+            {rows.map((row, idx) => (
+              <>
+                <tr
+                  key={row.label}
+                  className="align-top cursor-pointer"
+                  onClick={() => setOpenIndex(openIndex === idx ? null : idx)}
+                >
+                  <td className="pr-2 text-right whitespace-nowrap">
+                    {row.value.toLocaleString(undefined, {
+                      maximumFractionDigits: 2,
+                    })}
+                  </td>
+                  <td>
+                    <span className="font-semibold">{row.label}</span> {"="}{" "}
+                    {row.text}
+                  </td>
+                </tr>
+                {openIndex === idx && (
+                  <tr className="code-row">
+                    <td></td>
+                    <td>
+                      <pre className="code-window">{row.code}</pre>
+                    </td>
+                  </tr>
+                )}
+              </>
             ))}
           </tbody>
         </table>

--- a/frontend/src/model/subscription.ts
+++ b/frontend/src/model/subscription.ts
@@ -44,7 +44,7 @@ export interface SubscriptionResult {
     new_subscribers_monthly: number;
     blended_cpl: number;
     blended_cvr: number;
-    carbon_delivered: number;
+    carbon_ordered: number;
     carbon_spend_pct: number;
     blended_usd_per_ton: number;
     margin_warning: boolean;
@@ -186,7 +186,7 @@ export function runSubscriptionModel(
         leads_by_month[0] > 0
           ? (new_customers_by_month[0] / leads_by_month[0]) * 100
           : 0,
-      carbon_delivered: carbon_tons_by_month[carbon_tons_by_month.length - 1],
+      carbon_ordered: carbon_tons_by_month[carbon_tons_by_month.length - 1],
       carbon_spend_pct:
         mrr_by_month[mrr_by_month.length - 1] > 0
           ? (carbon_cost_by_month[carbon_cost_by_month.length - 1] /

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -30,7 +30,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .kpi-card{position:relative;background:var(--neutral-50);border-radius:8px;padding:var(--space-sm) var(--space-md) var(--space-xs);overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;box-shadow:0px -2px 2px 0px rgba(0,0,0,0.02) inset,0px 1.873px 23.41px 0px rgba(0,0,0,0.04);min-height:40px;}
 .kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--squid-ink);font-family:'Roboto Mono',monospace;line-height:1;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;}
-.kpi-card .metric-value{font-size:1.5rem;color:var(--success-500);}
+.kpi-card .metric-value{font-size:1.5rem;color:var(--accent-primary-500);}
 .kpi-card .top-row{display:flex;justify-content:space-between;align-items:center;}
 .kpi-card.warning .metric-value{color:var(--warning-600);}
 
@@ -203,3 +203,13 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .funnel-table th{color:var(--neutral-400);font-weight:500;}
 .funnel-table td{text-align:right;}
 .funnel-table td:first-child{text-align:left;}
+.funnel-table th:first-child{text-align:left;}
+
+.code-window{
+  background:#1e1e1e;
+  color:#e3e3e3;
+  padding:0.5rem;
+  border-radius:4px;
+  font-family:monospace;
+  font-size:0.75rem;
+}

--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -23,7 +23,7 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .kpi-card{position:relative;background:var(--neutral-50);border-radius:8px;padding:1rem;overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;box-shadow:0px -2px 2px 0px rgba(0,0,0,0.02) inset,0px 1.873px 23.41px 0px rgba(0,0,0,0.04);height:80px;}
 .kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--color-pearl);font-family:'Roboto Mono',monospace;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;font-size:2rem;}
-.kpi-card .metric-value{color:var(--color-limelight);}
+.kpi-card .metric-value{color:var(--accent-primary-500);}
 .kpi-card .top-row{display:flex;justify-content:space-between;align-items:flex-end;}
 .sparkline{display:block;width:100%;height:32px!important;pointer-events:none;clip-path:inset(0 round 8px);}
 
@@ -94,3 +94,5 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .overflow-y-auto { overflow-y: auto; } /* From HTML shell */
 
 
+\n.funnel-table th:first-child{text-align:left;}
+\n.code-window{background:#1e1e1e;color:#e3e3e3;padding:0.5rem;border-radius:4px;font-family:monospace;font-size:0.75rem;}


### PR DESCRIPTION
## Summary
- switch carbon terminology to "Carbon Ordered" and adjust KPI
- drop the Blended $/t KPI card and remove carbon from the MRR chart
- charts now start at 1 and subscriber metrics round to whole numbers
- sidebar height adjusted
- Model Equations rows now open a dark code window on click
- KPI metrics styled with cobalt brand color
- minor CSS tweaks for Funnel table

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `npm test` *(fails: jest not found)*