### PR TITLE
Enhance equation report and update defaults

### DIFF
--- a/frontend/src/model/constants.ts
+++ b/frontend/src/model/constants.ts
@@ -1,20 +1,20 @@
 export const DEFAULT_TIER_REVENUES = [500, 1200, 3000, 7500];
-export const DEFAULT_MARKETING_BUDGET = 10000;
-export const DEFAULT_COST_PER_LEAD = 150;
-export const DEFAULT_CONVERSION_RATE = 2.75; // percent
-export const DEFAULT_MONTHLY_CHURN_RATE = 10; // percent
+export const DEFAULT_MARKETING_BUDGET = 15000;
+export const DEFAULT_COST_PER_LEAD = 125;
+export const DEFAULT_CONVERSION_RATE = 3.5; // percent
+export const DEFAULT_MONTHLY_CHURN_RATE = 8; // percent
 export const DEFAULT_WACC = 8; // percent
 export const DEFAULT_INITIAL_CAC_SMB = 239;
 export const DEFAULT_PROJECTION_MONTHS = 24;
 export const DEFAULT_INITIAL_INVESTMENT = 200000;
-export const DEFAULT_OPERATING_EXPENSE_RATE = 15;
+export const DEFAULT_OPERATING_EXPENSE_RATE = 12;
 export const DEFAULT_FIXED_COSTS = 1500;
 export const MONTHLY_WACC = (0.08 / 12) * 100; // percent
 export const COST_PER_MILLE = 8; // cost per 1000 impressions
-export const DEFAULT_CTR = 1; // percent
+export const DEFAULT_CTR = 1.2; // percent
 // Default customer mix across pricing tiers, approximating a
 // typical distribution weighted toward lower tiers.
-export const DEFAULT_TIER_ADOPTION = [0.45, 0.3, 0.15, 0.1];
+export const DEFAULT_TIER_ADOPTION = [0.4, 0.3, 0.2, 0.1];
 
 export const TIER_CPL_FACTORS = [1, 1.6, 2.5, 4];
 export const TIER_CVR_FACTORS = [1, 0.65, 0.35, 0.15];

--- a/static/js/model/constants.js
+++ b/static/js/model/constants.js
@@ -1,8 +1,8 @@
 export const DEFAULT_TIER_REVENUES = [500, 1200, 3000, 7500];
-export const DEFAULT_MARKETING_BUDGET = 10000;
-export const DEFAULT_COST_PER_LEAD = 150;
-export const DEFAULT_CONVERSION_RATE = 2.5; // percent
-export const DEFAULT_MONTHLY_CHURN_RATE = 3; // percent
+export const DEFAULT_MARKETING_BUDGET = 15000;
+export const DEFAULT_COST_PER_LEAD = 125;
+export const DEFAULT_CONVERSION_RATE = 3.5; // percent
+export const DEFAULT_MONTHLY_CHURN_RATE = 8; // percent
 export const DEFAULT_WACC = 8; // percent
 export const DEFAULT_INITIAL_CAC_SMB = 239;
 export const DEFAULT_PROJECTION_MONTHS = 24;


### PR DESCRIPTION
## Summary
- tweak baseline constants to project reasonable growth
- style equation labels with cobalt brand color
- add carbon and tier pricing rows to the model equations table

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: jest not found)*