### PR TITLE
Update default CTR and integrate into projections

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -100,7 +100,7 @@ class ProjectionRequest(BaseModel):
     marketing_budget: float
     base_cpl: float
     base_cvr: float
-    ctr: float = 1.0
+    ctr: float = 18.0
     months: int = 24
 
 

--- a/backend/app/projection.py
+++ b/backend/app/projection.py
@@ -26,7 +26,7 @@ def run_projection(
     months: int = PROJECTION_MONTHS,
     base_cpl: float = BASE_CPL,
     base_cvr: float = BASE_CVR,
-    ctr: float = 1.0,
+    ctr: float = 18.0,
 ) -> Dict[str, List[float]]:
     flags = guardrail_flags(base_cpl, base_cvr)
     tier_cpl = [base_cpl * f for f in TIER_CPL_FACTORS]
@@ -49,7 +49,7 @@ def run_projection(
         imp = (marketing_budget / CPI) * 1000
         clk = imp * (ctr / 100.0)
         budgets = [marketing_budget * s for s in TIER_BUDGET_SPLIT]
-        leads = [b / c if c else 0 for b, c in zip(budgets, tier_cpl)]
+        leads = [(b / c) * (ctr / 100.0) if c else 0 for b, c in zip(budgets, tier_cpl)]
         new_cust = [l * (cv / 100.0) for l, cv in zip(leads, tier_cvr)]
         total_new = sum(new_cust)
         churned = active_customers * MONTHLY_CHURN

--- a/frontend/src/model/constants.ts
+++ b/frontend/src/model/constants.ts
@@ -11,7 +11,7 @@ export const DEFAULT_OPERATING_EXPENSE_RATE = 12;
 export const DEFAULT_FIXED_COSTS = 1500;
 export const MONTHLY_WACC = (0.08 / 12) * 100; // percent
 export const COST_PER_MILLE = 8; // cost per 1000 impressions
-export const DEFAULT_CTR = 1.2; // percent
+export const DEFAULT_CTR = 18; // percent
 // Default customer mix across pricing tiers, approximating a
 // typical distribution weighted toward lower tiers.
 export const DEFAULT_TIER_ADOPTION = [0.4, 0.3, 0.2, 0.1];


### PR DESCRIPTION
## Summary
- default CTR is now 18%
- allow CTR to affect leads and downstream KPIs

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: jest not found)*