### PR TITLE
Add AGEND and launcher script

### DIFF
--- a/AGEND.md
+++ b/AGEND.md
@@ -1,0 +1,22 @@
+# Project Agend
+
+This document tracks the current components and launch instructions for the prototype dashboard.
+
+## Components
+
+- **Backend**: FastAPI application in `backend/` exposing KPI, marketing audit, and projection endpoints.
+- **Frontend**: React app built with Vite located in `frontend/`.
+- **Tests**: Backend tests under `tests/` run with `pytest`; frontend uses Jest.
+- **Utilities**: `tools/debug_report.py` prints environment information.
+
+## Launching
+
+Install Python and Node dependencies, build the frontend, then run:
+
+```bash
+python3 launch.py
+```
+
+The script starts `uvicorn` and serves the bundled frontend on port 8001 by default.
+Set the `PORT` environment variable to override the port.
+

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ installed.
    serves the React app. If omitted, the server falls back to `frontend/index.html`.
 6. **Start the FastAPI server from the project root**
    ```bash
-   .venv/bin/uvicorn backend.app.main:app --reload
+   python3 launch.py
    ```
-   *(Adjust the path if your virtual environment lives elsewhere.)* Using the venv's `uvicorn` avoids accidentally launching a globally installed one.
+   *(Adjust the path if your virtual environment lives elsewhere.)* The script wraps `uvicorn` and automatically sets `PYTHONPATH` so you can run it from the project root.
 
    If you launch the server from another directory, set `PYTHONPATH=.` or use
    the `python3 -m` form:
@@ -75,11 +75,9 @@ cd ..
 Starting the server normally uses the bundled files in `frontend/dist`. When this folder is present, the backend automatically serves `index.html` and asset files from that directory:
 
 ```bash
-uvicorn backend.app.main:app --host 0.0.0.0 --port 8001
-# or if started from another directory
-# PYTHONPATH=. uvicorn backend.app.main:app --host 0.0.0.0 --port 8001
-# python3 -m uvicorn backend.app.main:app --host 0.0.0.0 --port 8001
+python3 launch.py
 ```
+The script accepts the `PORT` environment variable if you need to override the default of `8001`.
 
 
 ### Environment Variables

--- a/launch.py
+++ b/launch.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Convenience script to run the development server."""
+import os
+import sys
+from pathlib import Path
+import uvicorn
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def main():
+    port = int(os.environ.get("PORT", 8001))
+    uvicorn.run("backend.app.main:app", host="0.0.0.0", port=port, reload=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document project state and launching instructions in `AGEND.md`
- add a simple `launch.py` helper for running the dev server
- mention `launch.py` in the README

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: jest not found)*