### PR TITLE
Add Sankey chart for cash flows

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -26,6 +26,7 @@ import InlineNumberInput from "./components/InlineNumberInput";
 import ChartCard from "./components/ChartCard";
 import EquationReport from "./components/EquationReport";
 import FunnelTable from "./components/FunnelTable";
+import SankeyChart from "./components/SankeyChart";
 import { generateLegend } from "./utils/chartLegend";
 import { formatCurrency } from "./utils/format";
 import { getCssVar } from "./utils/cssVar";
@@ -116,14 +117,11 @@ export default function Dashboard() {
   });
   const [combinedLegend, setCombinedLegend] = useState<string>("");
   const [tierLegend, setTierLegend] = useState<string>("");
-  const [cashLegend, setCashLegend] = useState<string>("");
   const mrrCustRef = useRef<HTMLCanvasElement>(null);
   const tierRef = useRef<HTMLCanvasElement>(null);
-  const cashRef = useRef<HTMLCanvasElement>(null);
   const chartInstances = useRef<{
     combined?: Chart;
     tier?: Chart;
-    cash?: Chart;
   }>({});
   const [warning, setWarning] = useState(false);
 
@@ -328,59 +326,6 @@ export default function Dashboard() {
       }
     }
 
-    if (cashRef.current) {
-      const ctx = cashRef.current.getContext("2d");
-      if (ctx) {
-        const inflowColor = getCssVar("--success-500", cashRef.current!);
-        const outflowColor = getCssVar("--error-500", cashRef.current!);
-        const netColor = getCssVar("--information-500", cashRef.current!);
-        const inflows = financial.cashFlows.map((cf) => (cf > 0 ? cf : 0));
-        const outflows = financial.cashFlows.map((cf) => (cf < 0 ? -cf : 0));
-        const datasets = [
-          { label: "Inflow", data: inflows, backgroundColor: inflowColor },
-          { label: "Outflow", data: outflows, backgroundColor: outflowColor },
-          {
-            label: "Net",
-            data: financial.cashFlows,
-            type: "line" as const,
-            borderColor: netColor,
-            borderWidth: 2,
-            pointRadius: 0,
-            pointHoverRadius: 4,
-            tension: 0,
-          },
-        ];
-        if (!chartInstances.current.cash) {
-          chartInstances.current.cash = new Chart(ctx, {
-            type: "bar",
-            data: { labels, datasets },
-            options: {
-              responsive: true,
-              maintainAspectRatio: false,
-              plugins: { legend: { display: false } },
-              scales: {
-                x: { grid: { display: false } },
-                y: {
-                  ticks: {
-                    callback: (v: any) => "$" + formatCurrency(Number(v)),
-                  },
-                },
-              },
-            },
-          });
-        } else {
-          const ch = chartInstances.current.cash;
-          ch.data.labels = labels;
-          ch.data.datasets = datasets as any;
-          ch.update();
-        }
-        const legend =
-          `<span class="mr-2"><span style="color:${inflowColor}">↑</span> inflow</span>` +
-          `<span class="mr-2"><span style="color:${outflowColor}">↓</span> outflow</span>` +
-          `<span><span style="color:${netColor}">◆</span> net</span>`;
-        setCashLegend(legend);
-      }
-    }
     return () => {
       if (chartInstances.current.combined) {
         chartInstances.current.combined.destroy();
@@ -389,10 +334,6 @@ export default function Dashboard() {
       if (chartInstances.current.tier) {
         chartInstances.current.tier.destroy();
         delete chartInstances.current.tier;
-      }
-      if (chartInstances.current.cash) {
-        chartInstances.current.cash.destroy();
-        delete chartInstances.current.cash;
       }
     };
   }, [form]);
@@ -598,8 +539,16 @@ export default function Dashboard() {
           <ChartCard title="Revenue by Tier" legend={tierLegend}>
             <canvas ref={tierRef}></canvas>
           </ChartCard>
-          <ChartCard title="Cash Flows" legend={cashLegend}>
-            <canvas ref={cashRef}></canvas>
+          <ChartCard title="Cash Flows">
+            <SankeyChart
+              mrr={projections.mrr[0] || 0}
+              operatingExpenses={
+                (projections.mrr[0] || 0) * (form.operating_expense_rate / 100)
+              }
+              marketing={form.marketing_budget}
+              fixed={form.fixed_costs}
+              cash={projections.cashFlows[0] || 0}
+            />
           </ChartCard>
           <FunnelTable
             impressions={projections.impressions}

--- a/frontend/src/components/SankeyChart.tsx
+++ b/frontend/src/components/SankeyChart.tsx
@@ -1,0 +1,157 @@
+import { formatCurrency } from "../utils/format";
+
+interface Props {
+  mrr: number;
+  operatingExpenses: number;
+  marketing: number;
+  fixed: number;
+  cash: number;
+}
+
+export default function SankeyChart({
+  mrr,
+  operatingExpenses,
+  marketing,
+  fixed,
+  cash,
+}: Props) {
+  const inflowColor = "var(--success-500)";
+  const outflowColor = "var(--error-500)";
+  const netColor = "var(--information-500)";
+  const width = 600;
+  const height = 160;
+  const grossProfit = mrr - operatingExpenses;
+  const scale = (v: number, total: number) =>
+    Math.max(2, (v / (total || 1)) * 40);
+  const nodes = {
+    revenue: { x: 20, y: height / 2 },
+    opex: { x: 220, y: height * 0.25 },
+    gp: { x: 220, y: height * 0.75 },
+    marketing: { x: 420, y: height * 0.2 },
+    fixed: { x: 420, y: height * 0.5 },
+    cash: { x: 420, y: height * 0.8 },
+  } as const;
+  const path = (a: { x: number; y: number }, b: { x: number; y: number }) =>
+    `M ${a.x} ${a.y} C ${(a.x + b.x) / 2} ${a.y}, ${(a.x + b.x) / 2} ${b.y}, ${b.x} ${b.y}`;
+
+  const mrrToOpex = scale(operatingExpenses, mrr);
+  const mrrToGp = scale(grossProfit, mrr);
+  const gpToMarketing = scale(marketing, grossProfit);
+  const gpToFixed = scale(fixed, grossProfit);
+  const gpToCash = scale(cash, grossProfit);
+
+  return (
+    <svg
+      width="100%"
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="text-xs font-mono"
+    >
+      <defs>
+        <style>{`.node-label{fill:var(--squid-ink);}`}</style>
+      </defs>
+      <path
+        d={path(nodes.revenue, nodes.opex)}
+        stroke={outflowColor}
+        strokeWidth={mrrToOpex}
+        fill="none"
+        strokeOpacity="0.6"
+      />
+      <path
+        d={path(nodes.revenue, nodes.gp)}
+        stroke={inflowColor}
+        strokeWidth={mrrToGp}
+        fill="none"
+        strokeOpacity="0.6"
+      />
+      <path
+        d={path(nodes.gp, nodes.marketing)}
+        stroke={outflowColor}
+        strokeWidth={gpToMarketing}
+        fill="none"
+        strokeOpacity="0.6"
+      />
+      <path
+        d={path(nodes.gp, nodes.fixed)}
+        stroke={outflowColor}
+        strokeWidth={gpToFixed}
+        fill="none"
+        strokeOpacity="0.6"
+      />
+      <path
+        d={path(nodes.gp, nodes.cash)}
+        stroke={netColor}
+        strokeWidth={gpToCash}
+        fill="none"
+        strokeOpacity="0.6"
+      />
+
+      <text
+        className="node-label"
+        x={nodes.revenue.x - 10}
+        y={nodes.revenue.y - 8}
+        textAnchor="end"
+      >
+        Revenue
+      </text>
+      <text
+        className="node-label"
+        x={nodes.revenue.x - 10}
+        y={nodes.revenue.y + 8}
+        textAnchor="end"
+      >
+        {`$${formatCurrency(mrr)}`}
+      </text>
+      <text
+        className="node-label"
+        x={nodes.opex.x}
+        y={nodes.opex.y - 8}
+      >{`Opex`}</text>
+      <text
+        className="node-label"
+        x={nodes.opex.x}
+        y={nodes.opex.y + 8}
+      >{`$${formatCurrency(operatingExpenses)}`}</text>
+      <text
+        className="node-label"
+        x={nodes.gp.x}
+        y={nodes.gp.y - 8}
+      >{`Gross Profit`}</text>
+      <text
+        className="node-label"
+        x={nodes.gp.x}
+        y={nodes.gp.y + 8}
+      >{`$${formatCurrency(grossProfit)}`}</text>
+      <text
+        className="node-label"
+        x={nodes.marketing.x}
+        y={nodes.marketing.y - 8}
+      >{`Marketing`}</text>
+      <text
+        className="node-label"
+        x={nodes.marketing.x}
+        y={nodes.marketing.y + 8}
+      >{`$${formatCurrency(marketing)}`}</text>
+      <text
+        className="node-label"
+        x={nodes.fixed.x}
+        y={nodes.fixed.y - 8}
+      >{`Fixed`}</text>
+      <text
+        className="node-label"
+        x={nodes.fixed.x}
+        y={nodes.fixed.y + 8}
+      >{`$${formatCurrency(fixed)}`}</text>
+      <text
+        className="node-label"
+        x={nodes.cash.x}
+        y={nodes.cash.y - 8}
+      >{`Cash`}</text>
+      <text
+        className="node-label"
+        x={nodes.cash.x}
+        y={nodes.cash.y + 8}
+      >{`$${formatCurrency(cash)}`}</text>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- swap the bar-based cash flows chart for a new Sankey diagram
- wire Sankey inputs to model calculations

## Testing
- `pytest` *(fails: command not found)*
- `npm test --silent` *(fails: jest not found)*