### PR TITLE
Fix server script path resolution

### DIFF
--- a/tools/start_server.sh
+++ b/tools/start_server.sh
@@ -3,4 +3,10 @@
 
 set -e
 
+# Resolve the project root based on this script's location so the
+# launcher can be invoked from any working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
 python3 launch.py


### PR DESCRIPTION
## Summary
- ensure `start_server.sh` resolves the project root so it works from any directory

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*
- `npm test` *(fails: `jest: not found`)*