### PR TITLE
Improve env parsing

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,7 +23,9 @@ app = FastAPI(title="Catona Dashboard")
 
 
 def parse_env_list(name: str, default: str) -> List[str]:
-    return [item.strip() for item in os.getenv(name, default).split(",")]
+    """Return a cleaned list from a comma separated environment variable."""
+    value = os.getenv(name, default)
+    return [item.strip() for item in value.split(",") if item.strip()]
 
 
 origins = parse_env_list("CORS_ALLOW_ORIGINS", "http://localhost:3000")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,8 @@
+import os
+from backend.app.main import parse_env_list
+
+
+def test_parse_env_list_strips_and_ignores_empty(monkeypatch):
+    monkeypatch.setenv("TEST_ENV", " a , ,b ,, c ")
+    assert parse_env_list("TEST_ENV", "") == ["a", "b", "c"]
+    monkeypatch.delenv("TEST_ENV")


### PR DESCRIPTION
## Summary
- ignore empty items when parsing env vars
- test env parsing utility

## Testing
- `pytest -q` *(fails: command not found)*
- `npm test --silent` in `frontend/` *(fails: jest not found)*