### PR TITLE
Improve typing and clean metrics

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,17 +3,16 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
+from pathlib import Path
+from typing import Any, List, Optional, cast
 
 try:
     from fastapi.templating import Jinja2Templates
-    import jinja2
 
     _templates_available = True
 except Exception:  # Jinja2 may not be installed
-    Jinja2Templates = None
+    Jinja2Templates = cast(Any, None)  # type: ignore
     _templates_available = False
-from pathlib import Path
-from typing import List, Optional
 
 from pydantic import BaseModel
 from .marketing import calculate_tier_metrics, export_audit
@@ -23,7 +22,9 @@ app = FastAPI(title="Catona Dashboard")
 
 
 def parse_env_list(name: str, default: str) -> List[str]:
-    return [item.strip() for item in os.getenv(name, default).split(",")]
+    """Return a cleaned list from a comma separated environment variable."""
+    value = os.getenv(name, default)
+    return [item.strip() for item in value.split(",") if item.strip()]
 
 
 origins = parse_env_list("CORS_ALLOW_ORIGINS", "http://localhost:3000")

--- a/backend/app/marketing.py
+++ b/backend/app/marketing.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, TypedDict
 
 TIER_CPL_FACTORS: List[float] = [1.0, 1.6, 2.5, 4.0]
 TIER_CVR_FACTORS: List[float] = [1.0, 0.65, 0.35, 0.15]
@@ -13,6 +13,15 @@ BENCHMARK_RANGES: List[Dict[str, Tuple[float, float]]] = [
 ]
 
 
+class TierMetrics(TypedDict):
+    cpl: List[float]
+    cvr: List[float]
+    leads: List[float]
+    new_customers: List[float]
+    total_leads: float
+    total_new_customers: float
+
+
 def derive_cvr_by_tier(base_cvr: float) -> List[float]:
     """Return CVR percentages for each tier based on base CVR."""
     return [max(base_cvr * f, 0.1) for f in TIER_CVR_FACTORS]
@@ -25,7 +34,7 @@ def split_budget(total: float) -> List[float]:
 
 def calculate_tier_metrics(
     base_cvr: float, total_budget: float, ctr: float
-) -> Dict[str, object]:
+) -> TierMetrics:
     """Calculate CPL, CVR, leads and new customers for each tier."""
     budgets = split_budget(total_budget)
     impressions_total = (total_budget / CPI) * 1000
@@ -35,9 +44,9 @@ def calculate_tier_metrics(
         total_leads * ((b / f) / weight_sum) if weight_sum else 0
         for b, f in zip(budgets, TIER_CPL_FACTORS)
     ]
-    cpl = [b / l if l else 0 for b, l in zip(budgets, leads)]
+    cpl = [b / lead if lead else 0 for b, lead in zip(budgets, leads)]
     cvr = derive_cvr_by_tier(base_cvr)
-    new_customers = [l * (cv / 100.0) for l, cv in zip(leads, cvr)]
+    new_customers = [lead * (cv / 100.0) for lead, cv in zip(leads, cvr)]
     total_new_customers = sum(new_customers)
     return {
         "cpl": cpl,
@@ -65,7 +74,7 @@ def guardrail_flags(base_cvr: float) -> List[str]:
 def export_audit(
     base_cvr: float, total_budget: float, ctr: float
 ) -> List[Dict[str, object]]:
-    metrics = calculate_tier_metrics(base_cvr, total_budget, ctr)
+    metrics: TierMetrics = calculate_tier_metrics(base_cvr, total_budget, ctr)
     result = []
     for i in range(4):
         cpl_range = BENCHMARK_RANGES[i]["cpl"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,6 @@ from typing import List
 # Reuse the data models and handlers from the full application
 from backend.app.main import (
     KPI,
-    CalculationRequest,
     CalculationResponse,
     health,
     get_kpis,

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,7 @@
+from backend.app.main import parse_env_list
+
+
+def test_parse_env_list_strips_and_ignores_empty(monkeypatch):
+    monkeypatch.setenv("TEST_ENV", " a , ,b ,, c ")
+    assert parse_env_list("TEST_ENV", "") == ["a", "b", "c"]
+    monkeypatch.delenv("TEST_ENV")


### PR DESCRIPTION
## Summary
- type marketing metrics with a TypedDict
- define projection output schema
- rename loop variables and drop unused values
- allow optional templates without mypy errors

## Testing
- `mypy backend`
- `ruff check .`
- `pytest -q` *(fails: command not found)*
- `npm test --silent` *(fails: jest not found)*