### PR TITLE
Fix zero spend handling

### DIFF
--- a/backend/app/projection.py
+++ b/backend/app/projection.py
@@ -112,7 +112,11 @@ def run_projection(
     blended_cvr = (
         sum(new_customers_total) / sum(leads_total) * 100 if sum(leads_total) else 0
     )
-    blended_cpl = marketing_budget / (sum(leads_total) / months) if months else 0
+    blended_cpl = (
+        marketing_budget / (sum(leads_total) / months)
+        if months and sum(leads_total)
+        else 0
+    )
     ltv = (avg_price * (1 - OPERATING_EXPENSE_RATE)) / MONTHLY_CHURN
     payback = cac[-1] / (avg_price * (1 - OPERATING_EXPENSE_RATE)) if avg_price else 0
     npv = (

--- a/frontend/src/model/__tests__/subscription.test.ts
+++ b/frontend/src/model/__tests__/subscription.test.ts
@@ -1,6 +1,6 @@
-import { runSubscriptionModel } from '../subscription';
+import { runSubscriptionModel } from "../subscription";
 
-test('customer roll-forward logic', () => {
+test("customer roll-forward logic", () => {
   const result = runSubscriptionModel({
     projection_months: 2,
     churn_rate_smb: 10,
@@ -14,7 +14,7 @@ test('customer roll-forward logic', () => {
   expect(result.projections.customers_by_month[1]).toBeCloseTo(81.9915625);
 });
 
-test('MRR matches sum of tier revenues', () => {
+test("MRR matches sum of tier revenues", () => {
   const res = runSubscriptionModel({
     projection_months: 3,
     churn_rate_smb: 5,
@@ -25,7 +25,23 @@ test('MRR matches sum of tier revenues', () => {
     conversion_rate: 10,
   });
   res.projections.mrr_by_month.forEach((mrr, idx) => {
-    const sumTiers = res.projections.tier_revenue_by_month.reduce((a, arr) => a + arr[idx], 0);
+    const sumTiers = res.projections.tier_revenue_by_month.reduce(
+      (a, arr) => a + arr[idx],
+      0,
+    );
     expect(sumTiers).toBeCloseTo(mrr);
   });
+});
+
+test("zero marketing spend yields zero new customers", () => {
+  const res = runSubscriptionModel({
+    projection_months: 1,
+    churn_rate_smb: 5,
+    tier_revenues: [100],
+    initial_customers: 0,
+    marketing_budget: 0,
+    conversion_rate: 0,
+  });
+  expect(res.projections.new_customers_by_month[0]).toBe(0);
+  expect(res.projections.customers_by_month[0]).toBe(0);
 });

--- a/frontend/src/model/subscription.ts
+++ b/frontend/src/model/subscription.ts
@@ -69,7 +69,7 @@ export function runSubscriptionModel(
   const normalizedAdoption = adoption.map((r) => r / totalRate);
 
   const monthLabels = Array.from({ length: months }, (_, i) => `M${i + 1}`);
-  let customers = input.initial_customers || 10;
+  let customers = input.initial_customers ?? 10;
   const customers_by_month: number[] = [];
   const mrr_by_month: number[] = [];
   const deferred_by_month: number[] = [];
@@ -179,7 +179,7 @@ export function runSubscriptionModel(
           (1 - (input.operating_expense_rate ?? 0) / 100)) /
         (churn || 1),
       new_subscribers_monthly:
-        customers_by_month[1] - (input.initial_customers || 10),
+        customers_by_month[1] - (input.initial_customers ?? 10),
       blended_cpl:
         leads_by_month[0] > 0
           ? (input.marketing_budget ?? 0) / leads_by_month[0]

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -13,3 +13,9 @@ def test_projection_baseline_snapshot():
     inputs = json.load(open(Path("tests/fixtures/baseline_input.json")))
     expected = json.load(open(Path("tests/fixtures/baseline_output.json")))
     assert run_projection(**inputs) == expected
+
+
+def test_projection_zero_budget():
+    res = run_projection(0, months=1)
+    assert res["new_customers"] == [0]
+    assert res["active_customers"] == [0]


### PR DESCRIPTION
## Summary
- prevent divide-by-zero in projection when no leads
- allow zero `initial_customers` in subscription model
- test zero marketing budget on backend and frontend

## Testing
- `pytest -q` *(fails: command not found)*
- `npm test --silent` *(fails: jest not found)*