### PR TITLE
Add carbon tonnage derivation logic

### DIFF
--- a/frontend/src/model/__tests__/carbon.test.ts
+++ b/frontend/src/model/__tests__/carbon.test.ts
@@ -1,0 +1,6 @@
+import { deriveCarbonPerCustomer } from "../carbon";
+
+test("derive carbon tons logarithmically between margins", () => {
+  const res = deriveCarbonPerCustomer([100, 200, 300, 400], 10);
+  expect(res).toEqual([15, 27, 37, 44]);
+});

--- a/frontend/src/model/carbon.ts
+++ b/frontend/src/model/carbon.ts
@@ -1,0 +1,20 @@
+export function deriveCarbonPerCustomer(
+  tierPrices: number[],
+  costPerTon: number,
+  highMargin = 1.5,
+  lowMargin = 1.1,
+): number[] {
+  if (tierPrices.length === 0 || costPerTon <= 0) {
+    return [];
+  }
+  const n = tierPrices.length;
+  const startLn = Math.log(highMargin);
+  const endLn = Math.log(lowMargin);
+  return tierPrices.map((price, idx) => {
+    const ratio = n === 1 ? 0 : idx / (n - 1);
+    const lnFactor = startLn + (endLn - startLn) * ratio;
+    const factor = Math.exp(lnFactor);
+    const tons = (price / costPerTon) * factor;
+    return Math.round(tons);
+  });
+}

--- a/frontend/src/model/subscription.ts
+++ b/frontend/src/model/subscription.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_CTR,
   BLENDED_WEIGHTS,
 } from "./constants";
+import { deriveCarbonPerCustomer } from "./carbon";
 export interface SubscriptionInput {
   projection_months: number;
   churn_rate_smb: number;
@@ -83,7 +84,10 @@ export function runSubscriptionModel(
     input.carbon_per_customer &&
     input.carbon_per_customer.length === input.tier_revenues.length
       ? input.carbon_per_customer.slice()
-      : DEFAULT_TONS_PER_CUSTOMER.slice();
+      : deriveCarbonPerCustomer(
+          input.tier_revenues,
+          input.cost_of_carbon ?? DEFAULT_COST_OF_CARBON,
+        );
   const costPerTon = input.cost_of_carbon ?? DEFAULT_COST_OF_CARBON;
   const carbon_tons_by_month: number[] = [];
   const carbon_cost_by_month: number[] = [];


### PR DESCRIPTION
## Summary
- derive carbon volume from tier prices and cost of carbon
- use derivation in subscription model when carbon per customer isn't supplied
- test carbon derivation helper

## Testing
- `pytest` *(fails: No module named pytest)*
- `npm test` *(fails: jest not found)*