### PR TITLE
Improve carbon tier logic and styling

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -31,6 +31,7 @@ import SankeyChart from "./components/SankeyChart";
 import { generateLegend } from "./utils/chartLegend";
 import { formatCurrency } from "./utils/format";
 import { getCssVar } from "./utils/cssVar";
+import { deriveCarbonPerCustomer } from "./model/carbon";
 
 const TIER_COLORS = ["#4A47DC", "#8D8BE9", "#BF7DC4", "#E3C7E6"];
 
@@ -123,6 +124,40 @@ export default function Dashboard() {
     tier?: Chart;
   }>({});
   const [warning, setWarning] = useState(false);
+
+  useEffect(() => {
+    const prices = [
+      form.tier1_revenue,
+      form.tier2_revenue,
+      form.tier3_revenue,
+      form.tier4_revenue,
+    ];
+    const tons = deriveCarbonPerCustomer(prices, form.cost_of_carbon);
+    if (
+      tons[0] !== form.carbon1 ||
+      tons[1] !== form.carbon2 ||
+      tons[2] !== form.carbon3 ||
+      tons[3] !== form.carbon4
+    ) {
+      setForm((prev) => ({
+        ...prev,
+        carbon1: tons[0],
+        carbon2: tons[1],
+        carbon3: tons[2],
+        carbon4: tons[3],
+      }));
+    }
+  }, [
+    form.tier1_revenue,
+    form.tier2_revenue,
+    form.tier3_revenue,
+    form.tier4_revenue,
+    form.cost_of_carbon,
+    form.carbon1,
+    form.carbon2,
+    form.carbon3,
+    form.carbon4,
+  ]);
 
   useEffect(() => {
     const badCvr = form.conversion_rate < 0.1 || form.conversion_rate > 6;

--- a/frontend/src/components/EquationReport.tsx
+++ b/frontend/src/components/EquationReport.tsx
@@ -58,6 +58,12 @@ export default function EquationReport({ form, metrics, projections }: Props) {
     : 0;
   const carbonSpendPct = mrr ? (carbonCost / mrr) * 100 : 0;
   const usdPerTon = carbonTons ? carbonCost / carbonTons : 0;
+  const marginPerTier = [1, 2, 3, 4].map((n) => {
+    const rev = form[`tier${n}_revenue` as keyof typeof form] as number;
+    const tons = form[`carbon${n}` as keyof typeof form] as number;
+    const cost = tons * form.cost_of_carbon;
+    return rev ? ((rev - cost) / rev) * 100 : 0;
+  });
   const tierMetrics = calculateTierMetrics(
     form.conversion_rate,
     form.marketing_budget,
@@ -191,6 +197,18 @@ export default function EquationReport({ form, metrics, projections }: Props) {
       value: v,
       text: `Tier ${idx + 1} Leads`,
       code: `const tier${idx + 1}New = tier${idx + 1}Leads;`,
+    })),
+    ...marginPerTier.map((v, idx) => ({
+      label: `Tier ${idx + 1} Margin`,
+      value: v,
+      text: `((Tier ${idx + 1} Price - (Tier ${idx + 1} t × Cost per Ton)) / Tier ${
+        idx + 1
+      } Price) × 100`,
+      code: `const marginTier${idx + 1} = ((tier${
+        idx + 1
+      }Price - (tier${idx + 1}Tons * costPerTon)) / tier${
+        idx + 1
+      }Price) * 100;`,
     })),
   ];
 

--- a/frontend/src/model/__tests__/carbon.test.ts
+++ b/frontend/src/model/__tests__/carbon.test.ts
@@ -2,5 +2,5 @@ import { deriveCarbonPerCustomer } from "../carbon";
 
 test("derive carbon tons logarithmically between margins", () => {
   const res = deriveCarbonPerCustomer([100, 200, 300, 400], 10);
-  expect(res).toEqual([15, 27, 37, 44]);
+  expect(res).toEqual([7, 15, 25, 36]);
 });

--- a/frontend/src/model/carbon.ts
+++ b/frontend/src/model/carbon.ts
@@ -14,7 +14,7 @@ export function deriveCarbonPerCustomer(
     const ratio = n === 1 ? 0 : idx / (n - 1);
     const lnFactor = startLn + (endLn - startLn) * ratio;
     const factor = Math.exp(lnFactor);
-    const tons = (price / costPerTon) * factor;
+    const tons = price / (costPerTon * factor);
     return Math.round(tons);
   });
 }

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -205,11 +205,12 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .funnel-table th:first-child{text-align:left;}
 
 .code-window{
-  background:#1e1e1e;
-  color:#e3e3e3;
+  background:#f5f5f5;
+  color:#2d2d2d;
   padding:0.5rem;
   border-radius:4px;
-  font-family:monospace;
+  border:1px solid #e0e0e0;
+  font-family:"Roboto Mono",monospace;
   font-size:0.75rem;
 }
 


### PR DESCRIPTION
## Summary
- adjust derived carbon calculation to divide by margin
- auto-calc carbon per tier when prices or cost change
- add margin per tier equations
- lighten code snippet styling
- update tests for carbon logic

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: jest not found)*