### PR TITLE
Fix Sankey chart to show last month

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -385,6 +385,8 @@ export default function Dashboard() {
     setForm((prev) => ({ ...prev, [name]: value }));
   };
 
+  const lastIdx = Math.max(0, form.projection_months - 1);
+
   return (
     <div className="space-y-6">
       {warning && (
@@ -576,13 +578,14 @@ export default function Dashboard() {
             className="h-80 flex items-center justify-center"
           >
             <SankeyChart
-              mrr={projections.mrr[0] || 0}
+              mrr={projections.mrr[lastIdx] || 0}
               operatingExpenses={
-                (projections.mrr[0] || 0) * (form.operating_expense_rate / 100)
+                (projections.mrr[lastIdx] || 0) *
+                (form.operating_expense_rate / 100)
               }
               marketing={form.marketing_budget}
               fixed={form.fixed_costs}
-              cash={projections.cashFlows[0] || 0}
+              cash={projections.cashFlows[lastIdx] || 0}
               investment={form.initial_investment}
             />
           </ChartCard>

--- a/frontend/src/components/SankeyChart.tsx
+++ b/frontend/src/components/SankeyChart.tsx
@@ -42,7 +42,17 @@ export default function SankeyChart({
   const gpToMarketing = scale(marketing, grossProfit);
   const gpToFixed = scale(fixed, grossProfit);
   const gpToCash = scale(cash, grossProfit);
-  const investToCash = scale(investment, investment);
+
+  const investAlloc = {
+    marketing: investment * 0.4,
+    opex: investment * 0.3,
+    fixed: investment * 0.2,
+    cash: investment * 0.1,
+  };
+  const investToMarketing = scale(investAlloc.marketing, investment);
+  const investToOpex = scale(investAlloc.opex, investment);
+  const investToFixed = scale(investAlloc.fixed, investment);
+  const investToCash = scale(investAlloc.cash, investment);
 
   return (
     <svg
@@ -86,6 +96,27 @@ export default function SankeyChart({
         d={path(nodes.gp, nodes.cash)}
         stroke={netColor}
         strokeWidth={gpToCash}
+        fill="none"
+        strokeOpacity="0.6"
+      />
+      <path
+        d={path(nodes.investment, nodes.opex)}
+        stroke={outflowColor}
+        strokeWidth={investToOpex}
+        fill="none"
+        strokeOpacity="0.6"
+      />
+      <path
+        d={path(nodes.investment, nodes.marketing)}
+        stroke={outflowColor}
+        strokeWidth={investToMarketing}
+        fill="none"
+        strokeOpacity="0.6"
+      />
+      <path
+        d={path(nodes.investment, nodes.fixed)}
+        stroke={outflowColor}
+        strokeWidth={investToFixed}
         fill="none"
         strokeOpacity="0.6"
       />


### PR DESCRIPTION
## Summary
- use last projection month in Sankey
- allocate investment across opex, marketing, fixed and cash

## Testing
- `python -m pytest` *(fails: No module named pytest)*
- `npm test` *(fails: jest not found)*
