### PR TITLE
Update marketing spending logic

### DIFF
--- a/frontend/src/components/EquationReport.tsx
+++ b/frontend/src/components/EquationReport.tsx
@@ -71,145 +71,169 @@ export default function EquationReport({ form, metrics, projections }: Props) {
     COST_PER_MILLE,
   );
 
-  const rows = [
+  const sections = [
     {
-      label: "Impressions",
-      value: impressions,
-      text: "(Marketing Budget / Cost per 1K Impressions) × 1000",
-      code: "const impressions = (marketingBudget / COST_PER_MILLE) * 1000;",
+      title: "Funnel",
+      rows: [
+        {
+          label: "Impressions",
+          value: impressions,
+          text: "(Marketing Budget / Cost per 1K Impressions) × 1000",
+          code: "const impressions = (marketingBudget / COST_PER_MILLE) * 1000;",
+        },
+        {
+          label: "Clicks",
+          value: clicks,
+          text: "Impressions × CTR",
+          code: "const clicks = impressions * (ctr / 100);",
+        },
+        {
+          label: "Leads",
+          value: leads,
+          text: "Clicks × Conversion Rate",
+          code: "const leads = clicks * (conversionRate / 100);",
+        },
+        {
+          label: "New Customers",
+          value: newCustomers,
+          text: "Leads",
+          code: "const newCustomers = leads;",
+        },
+      ],
     },
     {
-      label: "Clicks",
-      value: clicks,
-      text: "Impressions × CTR",
-      code: "const clicks = impressions * (ctr / 100);",
+      title: "Customer Rollforward",
+      rows: [
+        {
+          label: "Churned Customers",
+          value: churned,
+          text: "Customers × Churn Rate",
+          code: "const churned = customers * (churnRate / 100);",
+        },
+        {
+          label: "Customers Next Month",
+          value: customersNext,
+          text: "Customers + New Customers − Churned Customers",
+          code: "const next = customers + newCustomers - churned;",
+        },
+      ],
     },
     {
-      label: "Leads",
-      value: leads,
-      text: "Clicks × Conversion Rate",
-      code: "const leads = clicks * (conversionRate / 100);",
+      title: "Revenue & Cash",
+      rows: [
+        {
+          label: "MRR",
+          value: mrr,
+          text: "Customers × Average Revenue Per Customer",
+          code: "const mrr = customers * arpc;",
+        },
+        {
+          label: "Subscriber LTV",
+          value: subscriberLtv,
+          text: "[Average Revenue Per Customer × (1 − Operating Expense %)] / Churn Rate",
+          code: "const ltv = (arpc * (1 - opexRate/100)) / churnRate;",
+        },
+        {
+          label: "Gross Profit",
+          value: grossProfit,
+          text: "MRR × (1 − Operating Expense %)",
+          code: "const grossProfit = mrr * (1 - opexRate/100);",
+        },
+        {
+          label: "Monthly Cash Flow",
+          value: monthlyCash,
+          text: "Gross Profit − Fixed Costs − Marketing Spend",
+          code: "const cash = grossProfit - fixedCosts - marketingBudget;",
+        },
+      ],
     },
     {
-      label: "New Customers",
-      value: newCustomers,
-      text: "Leads",
-      code: "const newCustomers = leads;",
+      title: "Blended Metrics",
+      rows: [
+        {
+          label: "Blended CPL",
+          value: blendedCpl,
+          text: "Marketing Budget / Weighted New Customers",
+          code: "const blendedCpl = marketingBudget / Σ(newCust[i] * weight[i]);",
+        },
+        {
+          label: "Blended CVR",
+          value: blendedCvr,
+          text: "(Weighted New Customers / Weighted Clicks) × 100",
+          code: "const blendedCvr = (Σ(newCust[i] * weight[i]) / Σ(clicks[i] * weight[i])) * 100;",
+        },
+        {
+          label: "NPV",
+          value: npv,
+          text: "∑ Cash Flow / (1 + WACC / 12)^n − Initial Investment",
+          code: "const npv = sum(cashFlow / (1 + wacc/12)**n) - initialInvestment;",
+        },
+      ],
     },
     {
-      label: "Churned Customers",
-      value: churned,
-      text: "Customers × Churn Rate",
-      code: "const churned = customers * (churnRate / 100);",
+      title: "Carbon",
+      rows: [
+        {
+          label: "Carbon Tons",
+          value: carbonTons,
+          text: "Customers × Tons per Customer",
+          code: "const carbonTons = customers * tonsPerCustomer;",
+        },
+        {
+          label: "Carbon Cost",
+          value: carbonCost,
+          text: "Carbon Tons × Cost of Carbon",
+          code: "const carbonCost = carbonTons * costPerTon;",
+        },
+        {
+          label: "Carbon Spend %",
+          value: carbonSpendPct,
+          text: "(Carbon Cost / MRR) × 100",
+          code: "const carbonSpendPct = (carbonCost / mrr) * 100;",
+        },
+        {
+          label: "USD per Ton",
+          value: usdPerTon,
+          text: "Carbon Cost / Carbon Tons",
+          code: "const usdPerTon = carbonCost / carbonTons;",
+        },
+      ],
     },
     {
-      label: "Customers Next Month",
-      value: customersNext,
-      text: "Customers + New Customers − Churned Customers",
-      code: "const next = customers + newCustomers - churned;",
+      title: "Tier Metrics",
+      rows: [
+        ...tierMetrics.cpl.map((v, idx) => ({
+          label: `Tier ${idx + 1} CPL`,
+          value: v,
+          text: `Budget × ${[0.4, 0.3, 0.2, 0.1][idx]} / Tier ${idx + 1} Leads`,
+          code: `const tier${idx + 1}Cpl = (totalBudget * ${[0.4, 0.3, 0.2, 0.1][idx]}) / tier${idx + 1}Leads;`,
+        })),
+        ...tierMetrics.cvr.map((v, idx) => ({
+          label: `Tier ${idx + 1} CVR`,
+          value: v,
+          text: `Base CVR × ${[1, 0.65, 0.35, 0.15][idx]}`,
+          code: `const tier${idx + 1}Cvr = Math.max(baseCvr * ${[1, 0.65, 0.35, 0.15][idx]}, 0.1);`,
+        })),
+        ...tierMetrics.leads.map((v, idx) => ({
+          label: `Tier ${idx + 1} Leads`,
+          value: v,
+          text: `Tier ${idx + 1} Clicks × (Tier ${idx + 1} CVR / 100)`,
+          code: `const tier${idx + 1}Leads = tier${idx + 1}Clicks * (tier${idx + 1}Cvr / 100);`,
+        })),
+        ...tierMetrics.newCustomers.map((v, idx) => ({
+          label: `Tier ${idx + 1} New Cust`,
+          value: v,
+          text: `Tier ${idx + 1} Leads`,
+          code: `const tier${idx + 1}New = tier${idx + 1}Leads;`,
+        })),
+        ...marginPerTier.map((v, idx) => ({
+          label: `Tier ${idx + 1} Margin`,
+          value: v,
+          text: `((Tier ${idx + 1} Price - (Tier ${idx + 1} t × Cost per Ton)) / Tier ${idx + 1} Price) × 100`,
+          code: `const marginTier${idx + 1} = ((tier${idx + 1}Price - (tier${idx + 1}Tons * costPerTon)) / tier${idx + 1}Price) * 100;`,
+        })),
+      ],
     },
-    {
-      label: "MRR",
-      value: mrr,
-      text: "Customers × Average Revenue Per Customer",
-      code: "const mrr = customers * arpc;",
-    },
-    {
-      label: "Subscriber LTV",
-      value: subscriberLtv,
-      text: "[Average Revenue Per Customer × (1 − Operating Expense %)] / Churn Rate",
-      code: "const ltv = (arpc * (1 - opexRate/100)) / churnRate;",
-    },
-    {
-      label: "Gross Profit",
-      value: grossProfit,
-      text: "MRR × (1 − Operating Expense %)",
-      code: "const grossProfit = mrr * (1 - opexRate/100);",
-    },
-    {
-      label: "Monthly Cash Flow",
-      value: monthlyCash,
-      text: "Gross Profit − Fixed Costs − Marketing Spend",
-      code: "const cash = grossProfit - fixedCosts - marketingBudget;",
-    },
-    {
-      label: "Blended CPL",
-      value: blendedCpl,
-      text: "Marketing Budget / Weighted New Customers",
-      code: "const blendedCpl = marketingBudget / Σ(newCust[i] * weight[i]);",
-    },
-    {
-      label: "Blended CVR",
-      value: blendedCvr,
-      text: "(Weighted New Customers / Weighted Clicks) × 100",
-      code: "const blendedCvr = (\u03a3(newCust[i] * weight[i]) / \u03a3(clicks[i] * weight[i])) * 100;",
-    },
-    {
-      label: "NPV",
-      value: npv,
-      text: "∑ Cash Flow / (1 + WACC / 12)^n − Initial Investment",
-      code: "const npv = sum(cashFlow / (1 + wacc/12)**n) - initialInvestment;",
-    },
-    {
-      label: "Carbon Tons",
-      value: carbonTons,
-      text: "Customers × Tons per Customer",
-      code: "const carbonTons = customers * tonsPerCustomer;",
-    },
-    {
-      label: "Carbon Cost",
-      value: carbonCost,
-      text: "Carbon Tons × Cost of Carbon",
-      code: "const carbonCost = carbonTons * costPerTon;",
-    },
-    {
-      label: "Carbon Spend %",
-      value: carbonSpendPct,
-      text: "(Carbon Cost / MRR) × 100",
-      code: "const carbonSpendPct = (carbonCost / mrr) * 100;",
-    },
-    {
-      label: "USD per Ton",
-      value: usdPerTon,
-      text: "Carbon Cost / Carbon Tons",
-      code: "const usdPerTon = carbonCost / carbonTons;",
-    },
-    ...tierMetrics.cpl.map((v, idx) => ({
-      label: `Tier ${idx + 1} CPL`,
-      value: v,
-      text: `Budget × ${[0.4, 0.3, 0.2, 0.1][idx]} / Tier ${idx + 1} Leads`,
-      code: `const tier${idx + 1}Cpl = (totalBudget * ${[0.4, 0.3, 0.2, 0.1][idx]}) / tier${idx + 1}Leads;`,
-    })),
-    ...tierMetrics.cvr.map((v, idx) => ({
-      label: `Tier ${idx + 1} CVR`,
-      value: v,
-      text: `Base CVR × ${[1, 0.65, 0.35, 0.15][idx]}`,
-      code: `const tier${idx + 1}Cvr = Math.max(baseCvr * ${[1, 0.65, 0.35, 0.15][idx]}, 0.1);`,
-    })),
-    ...tierMetrics.leads.map((v, idx) => ({
-      label: `Tier ${idx + 1} Leads`,
-      value: v,
-      text: `Tier ${idx + 1} Clicks × (Tier ${idx + 1} CVR / 100)`,
-      code: `const tier${idx + 1}Leads = tier${idx + 1}Clicks * (tier${idx + 1}Cvr / 100);`,
-    })),
-    ...tierMetrics.newCustomers.map((v, idx) => ({
-      label: `Tier ${idx + 1} New Cust`,
-      value: v,
-      text: `Tier ${idx + 1} Leads`,
-      code: `const tier${idx + 1}New = tier${idx + 1}Leads;`,
-    })),
-    ...marginPerTier.map((v, idx) => ({
-      label: `Tier ${idx + 1} Margin`,
-      value: v,
-      text: `((Tier ${idx + 1} Price - (Tier ${idx + 1} t × Cost per Ton)) / Tier ${
-        idx + 1
-      } Price) × 100`,
-      code: `const marginTier${idx + 1} = ((tier${
-        idx + 1
-      }Price - (tier${idx + 1}Tons * costPerTon)) / tier${
-        idx + 1
-      }Price) * 100;`,
-    })),
   ];
 
   return (
@@ -218,35 +242,57 @@ export default function EquationReport({ form, metrics, projections }: Props) {
       <Card>
         <table className="w-full text-xs font-mono">
           <tbody>
-            {rows.map((row, idx) => (
-              <>
-                <tr
-                  key={row.label}
-                  className="equation-row align-top cursor-pointer"
-                  onClick={() => setOpenIndex(openIndex === idx ? null : idx)}
-                >
-                  <td className="pr-2 text-right whitespace-nowrap">
-                    {row.value.toLocaleString(undefined, {
-                      maximumFractionDigits: 2,
-                    })}
-                  </td>
-                  <td>
-                    <span className="font-semibold text-[var(--cobalt-500)]">
-                      {row.label}
-                    </span>{" "}
-                    {"="} {row.text}
-                  </td>
-                </tr>
-                {openIndex === idx && (
-                  <tr className="code-row">
-                    <td></td>
-                    <td>
-                      <pre className="code-window">{row.code}</pre>
+            {(() => {
+              let i = 0;
+              return sections.map((sec, sIdx) => (
+                <Fragment key={sIdx}>
+                  <tr>
+                    <td
+                      colSpan={2}
+                      className="pt-2 font-semibold text-[var(--cobalt-700)]"
+                    >
+                      {sec.title}
                     </td>
                   </tr>
-                )}
-              </>
-            ))}
+                  {sec.rows.map((row) => {
+                    const idx = i++;
+                    return (
+                      <Fragment key={row.label}>
+                        <tr
+                          className="equation-row align-top cursor-pointer"
+                          onClick={() =>
+                            setOpenIndex(openIndex === idx ? null : idx)
+                          }
+                        >
+                          <td className="pr-2 text-right whitespace-nowrap">
+                            {row.value.toLocaleString(undefined, {
+                              maximumFractionDigits: 2,
+                            })}
+                          </td>
+                          <td>
+                            <span className="font-semibold text-[var(--cobalt-500)]">
+                              {row.label}
+                            </span>{" "}
+                            {"="} {row.text}
+                          </td>
+                        </tr>
+                        {openIndex === idx && (
+                          <tr className="code-row">
+                            <td></td>
+                            <td>
+                              <pre className="code-window">{row.code}</pre>
+                            </td>
+                          </tr>
+                        )}
+                      </Fragment>
+                    );
+                  })}
+                  <tr aria-hidden="true">
+                    <td colSpan={2} className="h-2"></td>
+                  </tr>
+                </Fragment>
+              ));
+            })()}
           </tbody>
         </table>
       </Card>

--- a/frontend/src/components/SankeyChart.tsx
+++ b/frontend/src/components/SankeyChart.tsx
@@ -20,19 +20,19 @@ export default function SankeyChart({
   const inflowColor = "var(--accent-primary-500)";
   const outflowColor = "var(--accent-secondary-500)";
   const netColor = "var(--accent-primary-300)";
-  const width = 600;
-  const height = 200;
+  const width = 720;
+  const height = 240;
   const grossProfit = mrr - operatingExpenses;
   const scale = (v: number, total: number) =>
     Math.max(2, (v / (total || 1)) * 40);
   const nodes = {
-    investment: { x: 20, y: height * 0.1 },
-    revenue: { x: 20, y: height / 2 },
-    opex: { x: 220, y: height * 0.25 },
-    gp: { x: 220, y: height * 0.75 },
-    marketing: { x: 420, y: height * 0.2 },
-    fixed: { x: 420, y: height * 0.5 },
-    cash: { x: 420, y: height * 0.8 },
+    investment: { x: 40, y: height * 0.15 },
+    revenue: { x: 40, y: height * 0.55 },
+    opex: { x: 360, y: height * 0.25 },
+    gp: { x: 360, y: height * 0.75 },
+    marketing: { x: 680, y: height * 0.35 },
+    fixed: { x: 680, y: height * 0.6 },
+    cash: { x: 680, y: height * 0.85 },
   } as const;
   const path = (a: { x: number; y: number }, b: { x: number; y: number }) =>
     `M ${a.x} ${a.y} C ${(a.x + b.x) / 2} ${a.y}, ${(a.x + b.x) / 2} ${b.y}, ${b.x} ${b.y}`;

--- a/frontend/src/model/constants.ts
+++ b/frontend/src/model/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_TIER_REVENUES = [500, 1200, 3000, 7500];
-export const DEFAULT_MARKETING_BUDGET = 15000;
+export const DEFAULT_MARKETING_BUDGET = 10000;
 export const DEFAULT_COST_PER_LEAD = 125;
 export const DEFAULT_CONVERSION_RATE = 1; // percent
 export const DEFAULT_MONTHLY_CHURN_RATE = 8; // percent

--- a/static/js/model/constants.js
+++ b/static/js/model/constants.js
@@ -1,5 +1,5 @@
 export const DEFAULT_TIER_REVENUES = [500, 1200, 3000, 7500];
-export const DEFAULT_MARKETING_BUDGET = 15000;
+export const DEFAULT_MARKETING_BUDGET = 10000;
 export const DEFAULT_COST_PER_LEAD = 125;
 export const DEFAULT_CONVERSION_RATE = 1; // percent
 export const DEFAULT_MONTHLY_CHURN_RATE = 8; // percent

--- a/static/js/model/finance.js
+++ b/static/js/model/finance.js
@@ -1,12 +1,20 @@
-export function calculateFinancialMetrics(modelResults, initialInvestment, expenses, wacc) {
+export function calculateFinancialMetrics(
+  modelResults,
+  initialInvestment,
+  expenses,
+  wacc,
+) {
   const grossProfits = modelResults.projections.mrr_by_month.map((mrr) => {
     return mrr * (1 - expenses.operatingExpenseRate / 100);
   });
 
   const monthlyMarketing = expenses.marketingSpend || 0;
+  let remainingInvestment = initialInvestment;
 
   const cashFlows = grossProfits.map((gp) => {
-    return gp - expenses.fixedCosts - monthlyMarketing;
+    const covered = Math.min(remainingInvestment, monthlyMarketing);
+    remainingInvestment -= covered;
+    return gp - expenses.fixedCosts - (monthlyMarketing - covered);
   });
 
   const waccMonthly = Math.pow(1 + wacc / 100, 1 / 12) - 1;
@@ -19,7 +27,10 @@ export function calculateFinancialMetrics(modelResults, initialInvestment, expen
   let paybackMonths = null;
   for (let i = 0; i < cashFlows.length; i++) {
     cumulative += cashFlows[i];
-    if (cumulative > 0) { paybackMonths = i + 1; break; }
+    if (cumulative > 0) {
+      paybackMonths = i + 1;
+      break;
+    }
   }
 
   return { npv, paybackMonths, cashFlows };


### PR DESCRIPTION
## Summary
- default marketing budget to $10k per month
- draw marketing spend from investment before cash flows
- expand and reposition Sankey chart
- organize equation report into titled sections

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `npm test` *(fails: jest not found)*