### PR TITLE
Fix missing React Fragment import

### DIFF
--- a/frontend/src/components/EquationReport.tsx
+++ b/frontend/src/components/EquationReport.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, Fragment } from "react";
 import Card from "./Card";
 import { calculateTierMetrics } from "../model/marketing";
 import { COST_PER_MILLE } from "../model/constants";


### PR DESCRIPTION
## Summary
- import Fragment for EquationReport to prevent runtime error

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: command not found)*