### PR TITLE
Implement roadmap UI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ npm test
 - Brand tokens are defined in `static/css/brand-tokens.css` and include the full Catona color palette and design variables.
 - This is not a production‑ready build but serves as a foundation for further development.
 
+## Prioritization Roadmap
+See [docs/prioritization_roadmap.md](docs/prioritization_roadmap.md) for the feature backlog.
+
 ## Debug Report
 
 Run `python3 tools/debug_report.py` to print helpful environment information. The script reports the Python version, installed packages, Node and npm versions, and values of key environment variables such as `CORS_ALLOW_ORIGINS`. The output is plain text so it can be easily copied into bug reports.

--- a/docs/prioritization_roadmap.md
+++ b/docs/prioritization_roadmap.md
@@ -1,0 +1,10 @@
+# Prioritization Roadmap
+
+This document outlines the current order of feature development based on impact and effort.
+
+1. **Inline validation & single‑click editing** – low effort with high impact on usability.
+2. **Read‑only styling & tooltips** – clarifies data when editing is disabled.
+3. **Sticky Key Metrics & animated chart transitions** – adds visual polish and improves comprehension.
+4. **Scenario save/load & export** – provides major value by allowing users to share and revisit models.
+5. **Accessibility improvements** – broad benefit and aligns with compliance requirements.
+

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -95,6 +95,27 @@ export default function Dashboard() {
 
   const [metrics, setMetrics] = useState<Metrics | null>(null);
   const [mobileOpen, setMobileOpen] = useState(false);
+  const saveScenario = () => {
+    localStorage.setItem("scenario", JSON.stringify(form));
+    alert("Scenario saved");
+  };
+  const loadScenario = () => {
+    const data = localStorage.getItem("scenario");
+    if (data) {
+      setForm(JSON.parse(data));
+    }
+  };
+  const exportScenario = () => {
+    const blob = new Blob([JSON.stringify(form, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "scenario.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
   const [projections, setProjections] = useState<{
     mrr: number[];
     subscribers: number[];
@@ -292,6 +313,7 @@ export default function Dashboard() {
             options: {
               responsive: true,
               maintainAspectRatio: false,
+              animation: { duration: 500 },
               plugins: { legend: { display: false } },
               scales: {
                 x: { grid: { display: false } },
@@ -340,6 +362,7 @@ export default function Dashboard() {
             options: {
               responsive: true,
               maintainAspectRatio: false,
+              animation: { duration: 500 },
               plugins: { legend: { display: false } },
               scales: {
                 x: { stacked: true, grid: { display: false } },
@@ -522,10 +545,33 @@ export default function Dashboard() {
           </div>
         </SidePanel>
         <div className="flex-1 space-y-4">
+          <div className="flex justify-end gap-2">
+            <button
+              className="btn"
+              onClick={saveScenario}
+              aria-label="Save scenario"
+            >
+              Save
+            </button>
+            <button
+              className="btn"
+              onClick={loadScenario}
+              aria-label="Load scenario"
+            >
+              Load
+            </button>
+            <button
+              className="btn"
+              onClick={exportScenario}
+              aria-label="Export scenario"
+            >
+              Export
+            </button>
+          </div>
           {metrics && (
             <>
               <h3 className="content-header">Key Metrics</h3>
-              <div id="kpiRow">
+              <div id="kpiRow" className="sticky-metrics">
                 <KPIChip
                   labelTop="Total"
                   labelBottom="MRR"

--- a/frontend/src/components/InlineNumberInput.tsx
+++ b/frontend/src/components/InlineNumberInput.tsx
@@ -8,6 +8,8 @@ interface Props {
   onChange: (value: number) => void;
   name?: string;
   id?: string;
+  disabled?: boolean;
+  tooltip?: string;
 }
 
 export default function InlineNumberInput({
@@ -17,9 +19,12 @@ export default function InlineNumberInput({
   onChange,
   name,
   id,
+  disabled = false,
+  tooltip,
 }: Props) {
   const [editing, setEditing] = useState(false);
   const [temp, setTemp] = useState<number>(value);
+  const [invalid, setInvalid] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const baseLabel = typeof label === "string" ? label : "input";
   const safeName = (name || baseLabel).replace(/\s+/g, "_").toLowerCase();
@@ -39,9 +44,12 @@ export default function InlineNumberInput({
 
   const handleBlur = () => {
     setEditing(false);
-    if (!isNaN(temp)) {
+    if (!isNaN(temp) && !invalid) {
       onChange(temp);
+    } else {
+      setTemp(value);
     }
+    setInvalid(false);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -51,7 +59,13 @@ export default function InlineNumberInput({
   };
 
   return (
-    <div className={`chip ${editing ? "editing" : ""}`}>
+    <div
+      className={`chip ${editing ? "editing" : ""} ${invalid ? "invalid" : ""} ${
+        disabled ? "readonly" : ""
+      }`}
+      onClick={() => inputRef.current?.focus()}
+      title={disabled ? tooltip : undefined}
+    >
       <span className="label">{label}</span>
       <span className="value" data-unit={unit}>
         {display}
@@ -65,8 +79,14 @@ export default function InlineNumberInput({
         step={unit === "percent" ? 0.5 : 1}
         onFocus={handleFocus}
         onBlur={handleBlur}
-        onChange={(e) => setTemp(parseFloat(e.target.value))}
+        readOnly={disabled}
+        onChange={(e) => {
+          const val = parseFloat(e.target.value);
+          setTemp(val);
+          setInvalid(isNaN(val));
+        }}
         onKeyDown={handleKeyDown}
+        aria-label={baseLabel}
       />
     </div>
   );

--- a/frontend/src/components/KPIChip.tsx
+++ b/frontend/src/components/KPIChip.tsx
@@ -36,7 +36,11 @@ export default function KPIChip({
           {labelBottom && <div className="leading-none">{labelBottom}</div>}
         </div>
         <div className="metric">
-          <span className="metric-value" data-unit={unit}>
+          <span
+            className="metric-value"
+            data-unit={unit}
+            aria-label={`${labelTop} ${labelBottom || ""}`.trim()}
+          >
             {displayValue}
           </span>
         </div>

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -56,6 +56,13 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
         width: 220px; /* Fixed width for scrollable items */
     }
 }
+#kpiRow.sticky-metrics{
+    position:sticky;
+    top:0;
+    background:var(--neutral-50);
+    z-index:var(--z-sticky);
+    padding-top:var(--space-sm);
+}
 @media(min-width:1024px){ /* lg breakpoint */
     #kpiRow{
         display:grid;
@@ -146,6 +153,14 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
 .chip.editing{
   border-color:var(--accent-primary-500);
   background:var(--neutral-100);
+}
+.chip.invalid{
+  border-color:var(--error-500);
+}
+.chip.readonly{
+  background:var(--neutral-100);
+  color:var(--neutral-400);
+  cursor:default;
 }
 .chip .label{
   font-weight:500;

--- a/tools/debug_report.py
+++ b/tools/debug_report.py
@@ -6,7 +6,9 @@ import sys
 def run_command(cmd):
     """Run a command and return its output or an error message."""
     try:
-        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=True)
+        result = subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=True
+        )
         return result.stdout.strip()
     except Exception as exc:
         return f"Error running {' '.join(cmd)}: {exc}"
@@ -18,26 +20,22 @@ def main():
     print()
 
     print("== Installed Packages ==")
-    print(run_command(['pip', 'freeze']))
+    print(run_command(["pip", "freeze"]))
     print()
 
     print("== Node Version ==")
-    print(run_command(['node', '--version']))
+    print(run_command(["node", "--version"]))
     print()
 
     print("== npm Version ==")
-    print(run_command(['npm', '--version']))
+    print(run_command(["npm", "--version"]))
     print()
 
-    env_vars = [
-        'CORS_ALLOW_ORIGINS',
-        'CORS_ALLOW_METHODS',
-        'CORS_ALLOW_HEADERS'
-    ]
+    env_vars = ["CORS_ALLOW_ORIGINS", "CORS_ALLOW_METHODS", "CORS_ALLOW_HEADERS"]
     print("== Environment Variables ==")
     for var in env_vars:
         print(f"{var}={os.getenv(var, '')}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add editable number input with validation and optional readonly mode
- implement scenario save/load/export buttons
- make KPI row sticky and animate charts
- minor accessibility tweaks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx'; jinja2 must be installed)*
- `npm test` *(fails: jest not found)*