### PR TITLE
Improve scenario save/load/export UX

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,17 +1,56 @@
-import { useEffect } from 'react';
-import Dashboard from './Dashboard';
-import Header from './components/Header';
-import { setupChartDefaults } from './chartConfig';
+import { useEffect, useState } from "react";
+import Dashboard from "./Dashboard";
+import Header from "./components/Header";
+import { setupChartDefaults } from "./chartConfig";
+import { ScenarioContext } from "./ScenarioContext";
+import type { FormState } from "./types";
+import {
+  DEFAULT_TIER_REVENUES,
+  DEFAULT_MARKETING_BUDGET,
+  DEFAULT_CONVERSION_RATE,
+  DEFAULT_MONTHLY_CHURN_RATE,
+  DEFAULT_WACC,
+  DEFAULT_PROJECTION_MONTHS,
+  DEFAULT_OPERATING_EXPENSE_RATE,
+  DEFAULT_FIXED_COSTS,
+  DEFAULT_INITIAL_INVESTMENT,
+  DEFAULT_CTR,
+  DEFAULT_COST_OF_CARBON,
+  DEFAULT_TONS_PER_CUSTOMER,
+} from "./model/constants";
 
 export default function App() {
   useEffect(() => {
     setupChartDefaults();
   }, []);
 
+  const [form, setForm] = useState<FormState>({
+    tier1_revenue: DEFAULT_TIER_REVENUES[0],
+    tier2_revenue: DEFAULT_TIER_REVENUES[1],
+    tier3_revenue: DEFAULT_TIER_REVENUES[2],
+    tier4_revenue: DEFAULT_TIER_REVENUES[3],
+    marketing_budget: DEFAULT_MARKETING_BUDGET,
+    conversion_rate: DEFAULT_CONVERSION_RATE,
+    ctr: DEFAULT_CTR,
+    churn_rate_smb: DEFAULT_MONTHLY_CHURN_RATE,
+    wacc: DEFAULT_WACC,
+    projection_months: DEFAULT_PROJECTION_MONTHS,
+    operating_expense_rate: DEFAULT_OPERATING_EXPENSE_RATE,
+    fixed_costs: DEFAULT_FIXED_COSTS,
+    initial_investment: DEFAULT_INITIAL_INVESTMENT,
+    cost_of_carbon: DEFAULT_COST_OF_CARBON,
+    carbon1: DEFAULT_TONS_PER_CUSTOMER[0],
+    carbon2: DEFAULT_TONS_PER_CUSTOMER[1],
+    carbon3: DEFAULT_TONS_PER_CUSTOMER[2],
+    carbon4: DEFAULT_TONS_PER_CUSTOMER[3],
+  });
+
   return (
-    <div className="max-w-[72rem] mx-auto px-6 space-y-6">
-      <Header />
-      <Dashboard />
-    </div>
+    <ScenarioContext.Provider value={{ form, setForm }}>
+      <div className="max-w-[72rem] mx-auto px-6 space-y-6">
+        <Header />
+        <Dashboard />
+      </div>
+    </ScenarioContext.Provider>
   );
 }

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -32,29 +32,10 @@ import { generateLegend } from "./utils/chartLegend";
 import { formatCurrency } from "./utils/format";
 import { getCssVar } from "./utils/cssVar";
 import { deriveCarbonPerCustomer } from "./model/carbon";
+import { useScenario } from "./ScenarioContext";
+import type { FormState } from "./types";
 
 const TIER_COLORS = ["#4A47DC", "#8D8BE9", "#BF7DC4", "#E3C7E6"];
-
-interface FormState {
-  tier1_revenue: number;
-  tier2_revenue: number;
-  tier3_revenue: number;
-  tier4_revenue: number;
-  marketing_budget: number;
-  conversion_rate: number;
-  ctr: number;
-  churn_rate_smb: number;
-  wacc: number;
-  projection_months: number;
-  operating_expense_rate: number;
-  fixed_costs: number;
-  initial_investment: number;
-  cost_of_carbon: number;
-  carbon1: number;
-  carbon2: number;
-  carbon3: number;
-  carbon4: number;
-}
 
 interface Metrics {
   total_mrr: number;
@@ -72,50 +53,9 @@ interface Metrics {
 }
 
 export default function Dashboard() {
-  const [form, setForm] = useState<FormState>({
-    tier1_revenue: DEFAULT_TIER_REVENUES[0],
-    tier2_revenue: DEFAULT_TIER_REVENUES[1],
-    tier3_revenue: DEFAULT_TIER_REVENUES[2],
-    tier4_revenue: DEFAULT_TIER_REVENUES[3],
-    marketing_budget: DEFAULT_MARKETING_BUDGET,
-    conversion_rate: DEFAULT_CONVERSION_RATE,
-    ctr: DEFAULT_CTR,
-    churn_rate_smb: DEFAULT_MONTHLY_CHURN_RATE,
-    wacc: DEFAULT_WACC,
-    projection_months: DEFAULT_PROJECTION_MONTHS,
-    operating_expense_rate: DEFAULT_OPERATING_EXPENSE_RATE,
-    fixed_costs: DEFAULT_FIXED_COSTS,
-    initial_investment: DEFAULT_INITIAL_INVESTMENT,
-    cost_of_carbon: DEFAULT_COST_OF_CARBON,
-    carbon1: DEFAULT_TONS_PER_CUSTOMER[0],
-    carbon2: DEFAULT_TONS_PER_CUSTOMER[1],
-    carbon3: DEFAULT_TONS_PER_CUSTOMER[2],
-    carbon4: DEFAULT_TONS_PER_CUSTOMER[3],
-  });
-
+  const { form, setForm } = useScenario();
   const [metrics, setMetrics] = useState<Metrics | null>(null);
   const [mobileOpen, setMobileOpen] = useState(false);
-  const saveScenario = () => {
-    localStorage.setItem("scenario", JSON.stringify(form));
-    alert("Scenario saved");
-  };
-  const loadScenario = () => {
-    const data = localStorage.getItem("scenario");
-    if (data) {
-      setForm(JSON.parse(data));
-    }
-  };
-  const exportScenario = () => {
-    const blob = new Blob([JSON.stringify(form, null, 2)], {
-      type: "application/json",
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "scenario.json";
-    a.click();
-    URL.revokeObjectURL(url);
-  };
   const [projections, setProjections] = useState<{
     mrr: number[];
     subscribers: number[];
@@ -608,29 +548,6 @@ export default function Dashboard() {
           </div>
         </SidePanel>
         <div className="flex-1 space-y-4">
-          <div className="flex justify-end gap-2">
-            <button
-              className="btn"
-              onClick={saveScenario}
-              aria-label="Save scenario"
-            >
-              Save
-            </button>
-            <button
-              className="btn"
-              onClick={loadScenario}
-              aria-label="Load scenario"
-            >
-              Load
-            </button>
-            <button
-              className="btn"
-              onClick={exportScenario}
-              aria-label="Export scenario"
-            >
-              Export
-            </button>
-          </div>
           {metrics && (
             <>
               <h3 className="content-header">Key Metrics</h3>

--- a/frontend/src/ScenarioContext.tsx
+++ b/frontend/src/ScenarioContext.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from "react";
+import type { FormState } from "./types";
+
+export const ScenarioContext = createContext<{
+  form: FormState;
+  setForm: React.Dispatch<React.SetStateAction<FormState>>;
+} | null>(null);
+
+export function useScenario() {
+  const ctx = useContext(ScenarioContext);
+  if (!ctx) {
+    throw new Error("ScenarioContext not found");
+  }
+  return ctx;
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,4 +1,5 @@
-import ApiStatus from '../ApiStatus';
+import ApiStatus from "../ApiStatus";
+import ScenarioControls from "./ScenarioControls";
 
 export default function Header() {
   return (
@@ -7,7 +8,10 @@ export default function Header() {
         <h1 className="main-header">SMB Program Modeling</h1>
         <p className="sub-header">Carbon Removal Subscription Service</p>
       </div>
-      <ApiStatus />
+      <div className="flex items-center gap-2">
+        <ApiStatus />
+        <ScenarioControls />
+      </div>
     </header>
   );
 }

--- a/frontend/src/components/ScenarioControls.tsx
+++ b/frontend/src/components/ScenarioControls.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { useScenario } from "../ScenarioContext";
+import type { FormState } from "../types";
+
+interface SavedScenario {
+  name: string;
+  data: FormState;
+}
+
+function getScenarios(): SavedScenario[] {
+  const raw = localStorage.getItem("scenarios");
+  return raw ? (JSON.parse(raw) as SavedScenario[]) : [];
+}
+
+function saveScenarios(list: SavedScenario[]) {
+  localStorage.setItem("scenarios", JSON.stringify(list));
+}
+
+export default function ScenarioControls() {
+  const { form, setForm } = useScenario();
+  const [showModal, setShowModal] = useState(false);
+  const [name, setName] = useState("");
+  const scenarios = getScenarios();
+
+  const handleSave = () => {
+    if (!name) return;
+    const updated = scenarios.filter((s) => s.name !== name);
+    updated.push({ name, data: form });
+    saveScenarios(updated);
+    setName("");
+    setShowModal(false);
+  };
+
+  const handleLoad = (n: string) => {
+    const found = scenarios.find((s) => s.name === n);
+    if (found) setForm(found.data);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <button className="btn" onClick={() => setShowModal(true)}>
+        Save
+      </button>
+      <select
+        className="btn"
+        onChange={(e) => handleLoad(e.target.value)}
+        defaultValue=""
+      >
+        <option value="" disabled>
+          {scenarios.length ? "Load" : "No Scenarios Saved"}
+        </option>
+        {scenarios.map((s) => (
+          <option key={s.name} value={s.name}>
+            {s.name}
+          </option>
+        ))}
+      </select>
+      <button className="btn" onClick={() => window.print()}>
+        Export
+      </button>
+      {showModal && (
+        <div className="modal-overlay">
+          <div className="modal space-y-2">
+            <input
+              className="w-full"
+              placeholder="Scenario Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <div className="flex justify-end gap-2">
+              <button className="btn" onClick={() => setShowModal(false)}>
+                Cancel
+              </button>
+              <button className="btn" onClick={handleSave}>
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -7,7 +7,8 @@ h1,h2,h3,h4,h5,h6{font-family:'Inter',sans-serif;}
 .card{background:var(--cat-neutral-50);border-radius:12px;box-shadow:none;}
 .btn,button{border-radius:9999px;padding:.5rem 1.25rem;cursor:pointer; border: 1px solid transparent; /* Added for consistency */}
 input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
-             padding:.5rem 1rem;background:#fff;}
+             padding:.5rem 1rem;background:#fff;color:var(--color-squid-ink);}
+input::placeholder{color:var(--color-neutral-200);}
 
 /* simple color swatch */
 .swatch{display:inline-block;width:16px;height:16px;border-radius:4px;margin-right:8px;}
@@ -233,3 +234,6 @@ input,select{border:1px solid var(--cat-driftwood);border-radius:9999px;
   background:var(--color-neutral-100);
   transition:background .2s;
 }
+
+.modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;display:flex;justify-content:center;align-items:center;background:rgba(0,0,0,0.5);z-index:50;}
+.modal{background:#fff;border-radius:8px;padding:1rem;box-shadow:0 2px 10px rgba(0,0,0,0.3);}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,20 @@
+export interface FormState {
+  tier1_revenue: number;
+  tier2_revenue: number;
+  tier3_revenue: number;
+  tier4_revenue: number;
+  marketing_budget: number;
+  conversion_rate: number;
+  ctr: number;
+  churn_rate_smb: number;
+  wacc: number;
+  projection_months: number;
+  operating_expense_rate: number;
+  fixed_costs: number;
+  initial_investment: number;
+  cost_of_carbon: number;
+  carbon1: number;
+  carbon2: number;
+  carbon3: number;
+  carbon4: number;
+}


### PR DESCRIPTION
## Summary
- move scenario save/load/export buttons to header
- add ScenarioControls component with modal UI for named scenarios
- store scenarios in localStorage and allow loading
- wrap app in ScenarioContext so header can access form
- tweak input placeholder style and add modal styles

## Testing
- `pytest` *(fails: ModuleNotFoundError: httpx)*
- `npm test` *(fails: jest not found)*