### PR TITLE
Update outflow chart colors

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -28,7 +28,7 @@ import ChartCard from "./components/ChartCard";
 import EquationReport from "./components/EquationReport";
 import FunnelTable from "./components/FunnelTable";
 import SankeyChart from "./components/SankeyChart";
-import { generateLegend } from "./utils/chartLegend";
+import { generateLegend, generateBarLegend } from "./utils/chartLegend";
 import { formatCurrency } from "./utils/format";
 import { getCssVar } from "./utils/cssVar";
 import { deriveCarbonPerCustomer } from "./model/carbon";
@@ -407,10 +407,10 @@ export default function Dashboard() {
         const labelsOut = ["Marketing", "Opex", "Fixed", "Carbon"];
         const dataOut = [totalMarketing, totalOpex, totalFixed, totalCarbon];
         const colors = [
-          getCssVar("--accent-secondary-500", outflowRef.current),
-          getCssVar("--accent-primary-500", outflowRef.current),
+          getCssVar("--cobalt-300", outflowRef.current),
+          getCssVar("--cobalt-400", outflowRef.current),
           getCssVar("--cobalt-500", outflowRef.current),
-          getCssVar("--success-500", outflowRef.current),
+          getCssVar("--cobalt-600", outflowRef.current),
         ];
         if (!chartInstances.current.outflow) {
           chartInstances.current.outflow = new Chart(ctx, {
@@ -442,7 +442,7 @@ export default function Dashboard() {
           ch.update();
         }
         if (chartInstances.current.outflow) {
-          setOutflowLegend(generateLegend(chartInstances.current.outflow));
+          setOutflowLegend(generateBarLegend(labelsOut, colors));
         }
       }
     }

--- a/frontend/src/styles/brand-tokens.css
+++ b/frontend/src/styles/brand-tokens.css
@@ -185,5 +185,14 @@
   --neutral-300: var(--color-neutral-300);
   --neutral-400: var(--color-neutral-400);
   --neutral-500: var(--color-neutral-500);
+  --cobalt-50: var(--accent-primary-50);
+  --cobalt-100: var(--accent-primary-100);
+  --cobalt-200: var(--accent-primary-200);
+  --cobalt-300: var(--accent-primary-300);
+  --cobalt-400: var(--accent-primary-400);
   --cobalt-500: var(--accent-primary-500);
+  --cobalt-600: var(--accent-primary-600);
+  --cobalt-700: var(--accent-primary-700);
+  --cobalt-800: var(--accent-primary-800);
+  --cobalt-900: var(--accent-primary-900);
 }

--- a/frontend/src/utils/chartLegend.ts
+++ b/frontend/src/utils/chartLegend.ts
@@ -1,11 +1,21 @@
-export function generateLegend(chart: import('chart.js').Chart): string {
+export function generateLegend(chart: import("chart.js").Chart): string {
   const { datasets } = chart.data;
   const items = datasets.map((ds: any) => {
-    const color = ds.borderColor || ds.backgroundColor || '#000';
-    const label = ds.label || '';
+    const color = ds.borderColor || ds.backgroundColor || "#000";
+    const label = ds.label || "";
     return `<span style="display:inline-flex;align-items:center;margin-right:8px;">
       <span style="background-color:${color};width:10px;height:10px;display:inline-block;margin-right:4px;"></span>${label}
     </span>`;
   });
-  return items.join('');
+  return items.join("");
+}
+
+export function generateBarLegend(labels: string[], colors: string[]): string {
+  const items = labels.map((label, idx) => {
+    const color = colors[idx] || "#000";
+    return `<span style="display:inline-flex;align-items:center;margin-right:8px;">
+      <span style="background-color:${color};width:10px;height:10px;display:inline-block;margin-right:4px;"></span>${label}
+    </span>`;
+  });
+  return items.join("");
 }

--- a/static/css/brand-tokens.css
+++ b/static/css/brand-tokens.css
@@ -185,5 +185,14 @@
   --neutral-300: var(--color-neutral-300);
   --neutral-400: var(--color-neutral-400);
   --neutral-500: var(--color-neutral-500);
+  --cobalt-50: var(--accent-primary-50);
+  --cobalt-100: var(--accent-primary-100);
+  --cobalt-200: var(--accent-primary-200);
+  --cobalt-300: var(--accent-primary-300);
+  --cobalt-400: var(--accent-primary-400);
   --cobalt-500: var(--accent-primary-500);
+  --cobalt-600: var(--accent-primary-600);
+  --cobalt-700: var(--accent-primary-700);
+  --cobalt-800: var(--accent-primary-800);
+  --cobalt-900: var(--accent-primary-900);
 }


### PR DESCRIPTION
## Summary
- add cobalt color scale tokens
- expose a custom bar legend utility
- use cobalt shades for outflow chart

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', jinja2 must be installed)*
- `npm test --silent` *(fails: jest not found)*