### PR TITLE
Refine header layout and colors

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,12 +3,12 @@ import ScenarioControls from "./ScenarioControls";
 
 export default function Header() {
   return (
-    <header className="flex items-center justify-between py-4">
+    <header className="flex items-start justify-between py-4">
       <div>
         <h1 className="main-header">SMB Program Modeling</h1>
         <p className="sub-header">Carbon Removal Subscription Service</p>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-col items-end gap-2">
         <ApiStatus />
         <ScenarioControls />
       </div>

--- a/frontend/src/components/ScenarioControls.tsx
+++ b/frontend/src/components/ScenarioControls.tsx
@@ -38,11 +38,11 @@ export default function ScenarioControls() {
 
   return (
     <div className="flex items-center gap-2">
-      <button className="btn" onClick={() => setShowModal(true)}>
+      <button className="btn text-sm" onClick={() => setShowModal(true)}>
         Save
       </button>
       <select
-        className="btn"
+        className="btn text-sm"
         onChange={(e) => handleLoad(e.target.value)}
         defaultValue=""
       >
@@ -55,7 +55,7 @@ export default function ScenarioControls() {
           </option>
         ))}
       </select>
-      <button className="btn" onClick={() => window.print()}>
+      <button className="btn text-sm" onClick={() => window.print()}>
         Export
       </button>
       {showModal && (
@@ -68,10 +68,13 @@ export default function ScenarioControls() {
               onChange={(e) => setName(e.target.value)}
             />
             <div className="flex justify-end gap-2">
-              <button className="btn" onClick={() => setShowModal(false)}>
+              <button
+                className="btn text-sm"
+                onClick={() => setShowModal(false)}
+              >
                 Cancel
               </button>
-              <button className="btn" onClick={handleSave}>
+              <button className="btn text-sm" onClick={handleSave}>
                 Save
               </button>
             </div>

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -1,7 +1,7 @@
 @import "brand-tokens.css";
 
 /* base */
-body{margin:0;font-family:'Roboto Mono',monospace;background:var(--cat-pearl);color:var(--squid-ink);}
+body{margin:0;font-family:'Roboto Mono',monospace;background:var(--color-pearl);color:var(--squid-ink);}
 h1,h2,h3,h4,h5,h6{font-family:'Inter',sans-serif;}
 .shadow-surface{box-shadow:none;}
 .card{background:var(--cat-neutral-50);border-radius:8px;box-shadow:none;}

--- a/static/css/design-system.css
+++ b/static/css/design-system.css
@@ -1,7 +1,7 @@
 @import "brand-tokens.css";
 
 /* base */
-body{margin:0;font-family:system-ui;background:var(--cat-pearl);}
+body{margin:0;font-family:system-ui;background:var(--color-pearl);}
 .card{background:var(--cat-neutral-50);border-radius:12px;
       box-shadow:0px -2px 2px 0px rgba(0,0,0,0.02) inset,
                  0px 1.873px 23.41px 0px rgba(0,0,0,0.04);}


### PR DESCRIPTION
## Summary
- set site background to `--color-pearl`
- top align header elements and position API status in top-right
- reduce header menu font size for a lighter look

## Testing
- `pytest` *(fails: ModuleNotFoundError: httpx, jinja2 must be installed)*
- `npm test` *(fails: jest not found)*