### PR TITLE
Add seasonality slider and padding fix

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import {
   DEFAULT_CTR,
   DEFAULT_COST_OF_CARBON,
   DEFAULT_TONS_PER_CUSTOMER,
+  DEFAULT_SEASONALITY,
 } from "./model/constants";
 
 export default function App() {
@@ -43,6 +44,8 @@ export default function App() {
     carbon2: DEFAULT_TONS_PER_CUSTOMER[1],
     carbon3: DEFAULT_TONS_PER_CUSTOMER[2],
     carbon4: DEFAULT_TONS_PER_CUSTOMER[3],
+    seasonality: DEFAULT_SEASONALITY,
+    seasonality_influence: 0,
   });
 
   return (

--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -18,6 +18,7 @@ import {
   BLENDED_WEIGHTS,
 } from "./model/constants";
 import { runSubscriptionModel } from "./model/subscription";
+import { blendSeasonality } from "./utils/seasonality";
 import { calculateFinancialMetrics } from "./model/finance";
 import { calculateTierMetrics } from "./model/marketing";
 import { Chart } from "chart.js/auto";
@@ -185,7 +186,11 @@ export default function Dashboard() {
       : 0;
     const blendedCpl = weightedNew ? form.marketing_budget / weightedNew : 0;
 
-    const results = runSubscriptionModel(modelInput);
+    const blend = blendSeasonality(
+      form.seasonality,
+      form.seasonality_influence,
+    );
+    const results = runSubscriptionModel(modelInput, blend);
     const financial = calculateFinancialMetrics(
       results,
       form.initial_investment,
@@ -495,6 +500,24 @@ export default function Dashboard() {
               value={form.ctr}
               onChange={(v) => handleValueChange("ctr", v)}
             />
+            <div className="space-y-1">
+              <label className="text-sm">
+                Seasonality Influence {form.seasonality_influence}%
+              </label>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={form.seasonality_influence}
+                onChange={(e) =>
+                  handleValueChange(
+                    "seasonality_influence",
+                    parseFloat(e.target.value),
+                  )
+                }
+                className="w-full"
+              />
+            </div>
             <p className="text-xs text-[var(--neutral-500)]">
               Upper tiers scale automatically: CPL factors 1 / 1.6 / 2.5 / 4.0,
               CVR factors 1 / 0.65 / 0.35 / 0.15

--- a/frontend/src/model/constants.ts
+++ b/frontend/src/model/constants.ts
@@ -24,3 +24,6 @@ export const TIER_BUDGET_SPLIT = [0.4, 0.3, 0.2, 0.1];
 
 export const DEFAULT_COST_OF_CARBON = 18;
 export const DEFAULT_TONS_PER_CUSTOMER = [10, 25, 70, 200];
+export const DEFAULT_SEASONALITY = [
+  0.08, 0.08, 0.09, 0.1, 0.09, 0.08, 0.07, 0.07, 0.08, 0.1, 0.13, 0.13,
+];

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -27,7 +27,7 @@ input::placeholder{color:var(--color-neutral-200);}
 .metric-label{font-size:0.875rem;color:var(--neutral-400);font-family:'Roboto Mono',monospace;}
 
 /* KPI chips */
-.kpi-card{position:relative;background:var(--neutral-50);border-radius:8px;padding:var(--space-sm) var(--space-md) var(--space-xs);overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;box-shadow:none;min-height:40px;}
+.kpi-card{position:relative;background:var(--neutral-50);border-radius:8px;padding:var(--space-sm) var(--space-md);overflow:hidden;display:flex;flex-direction:column;gap:0.5rem;box-shadow:none;min-height:40px;}
 .kpi-card .label-block div{font-size:0.75rem;font-weight:500;color:var(--squid-ink);font-family:'Roboto Mono',monospace;line-height:1;}
 .kpi-card .metric{position:relative;z-index:2;font-family:'Inter',sans-serif;font-weight:700;}
 .kpi-card .metric-value{font-size:1.5rem;color:var(--accent-primary-500);}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -17,4 +17,6 @@ export interface FormState {
   carbon2: number;
   carbon3: number;
   carbon4: number;
+  seasonality: number[];
+  seasonality_influence: number;
 }

--- a/frontend/src/utils/seasonality.ts
+++ b/frontend/src/utils/seasonality.ts
@@ -1,0 +1,13 @@
+export function blendSeasonality(
+  seasonality: number[],
+  sliderValue: number,
+): number[] {
+  const len = seasonality.length;
+  const uniform = Array(len).fill(1 / len);
+  const s = sliderValue / 100;
+  const raw = seasonality.map(
+    (val, i) => Math.pow(uniform[i], 1 - s) * Math.pow(val, s),
+  );
+  const total = raw.reduce((a, b) => a + b, 0);
+  return raw.map((v) => v / total);
+}


### PR DESCRIPTION
## Summary
- make KPI card padding uniform
- add default seasonality constants and types
- provide seasonality influence slider and blending logic
- apply blended seasonality in subscription model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent` *(fails: jest: not found)*