### PR TITLE
Fix seasonality slider impact

### DIFF
--- a/frontend/src/model/__tests__/subscription.test.ts
+++ b/frontend/src/model/__tests__/subscription.test.ts
@@ -1,4 +1,6 @@
 import { runSubscriptionModel } from "../subscription";
+import { blendSeasonality } from "../../utils/seasonality";
+import { DEFAULT_SEASONALITY } from "../constants";
 
 test("customer roll-forward logic", () => {
   const result = runSubscriptionModel({
@@ -45,4 +47,22 @@ test("zero marketing spend yields zero new customers", () => {
   });
   expect(res.projections.new_customers_by_month[0]).toBe(0);
   expect(res.projections.customers_by_month[0]).toBe(0);
+});
+
+test("seasonality influence never increases MRR", () => {
+  const input = {
+    projection_months: 12,
+    churn_rate_smb: 5,
+    tier_revenues: [100],
+    initial_customers: 100,
+    marketing_budget: 1000,
+    conversion_rate: 10,
+    ctr: 18,
+  };
+  const baseline = runSubscriptionModel(input);
+  const blend = blendSeasonality(DEFAULT_SEASONALITY, 100);
+  const withSeasonality = runSubscriptionModel(input, blend);
+  withSeasonality.projections.mrr_by_month.forEach((mrr, idx) => {
+    expect(mrr).toBeLessThanOrEqual(baseline.projections.mrr_by_month[idx]);
+  });
 });

--- a/frontend/src/model/subscription.ts
+++ b/frontend/src/model/subscription.ts
@@ -115,7 +115,7 @@ export function runSubscriptionModel(
   const free_cash_flow: number[] = [];
 
   for (let i = 0; i < months; i++) {
-    const monthFactor = blend[i % 12] * 12;
+    const monthFactor = Math.min(blend[i % 12] * 12, 1);
     const monthBudget = (input.marketing_budget ?? 0) * monthFactor;
     const tierMetrics =
       monthBudget && input.conversion_rate


### PR DESCRIPTION
## Summary
- cap monthly budget scaling so seasonality slider only reduces marketing spend
- test that seasonality influence never raises MRR

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx', AssertionError: jinja2 must be installed)*
- `npm test` *(fails: jest not found)*