### PR TITLE
Fix chart layers and legend

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -278,6 +278,7 @@ export default function Dashboard() {
             data: mrrArr,
             borderColor: mrrColor,
             backgroundColor: mrrColor,
+            legendColor: mrrColor,
             borderWidth: 2,
             yAxisID: "y1",
             pointRadius: 0,
@@ -298,12 +299,14 @@ export default function Dashboard() {
               label: `Tier ${idx + 1}`,
               data: arr,
               borderColor: grad,
+              legendColor: endColor,
               borderWidth: 4,
               yAxisID: "y2",
               pointRadius: 0,
               pointHoverRadius: 4,
               tension: 0.16,
               fill: false,
+              order: idx + 1,
             };
           }),
         ];

--- a/frontend/src/utils/chartLegend.ts
+++ b/frontend/src/utils/chartLegend.ts
@@ -1,7 +1,9 @@
 export function generateLegend(chart: import("chart.js").Chart): string {
   const { datasets } = chart.data;
   const items = datasets.map((ds: any) => {
-    const color = ds.borderColor || ds.backgroundColor || "#000";
+    const rawColor =
+      ds.legendColor || ds.borderColor || ds.backgroundColor || "#000";
+    const color = typeof rawColor === "string" ? rawColor : "#000";
     const label = ds.label || "";
     return `<span style="display:inline-flex;align-items:center;margin-right:8px;">
       <span style="background-color:${color};width:10px;height:10px;display:inline-block;margin-right:4px;"></span>${label}


### PR DESCRIPTION
## Summary
- keep the MRR area behind tier lines
- ensure legend chips work with gradients

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx', jinja2 must be installed)*
- `npm test` in `frontend` *(fails: jest not found)*