### PR TITLE
Fix legend order for MRR dataset

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -272,41 +272,43 @@ export default function Dashboard() {
       const ctx = mrrCustRef.current.getContext("2d");
       if (ctx) {
         const mrrColor = getCssVar("--color-limelight", mrrCustRef.current!);
-        const datasets = [
-          {
-            label: "MRR",
-            data: mrrArr,
-            borderColor: mrrColor,
-            backgroundColor: mrrColor,
-            borderWidth: 2,
-            yAxisID: "y1",
+        const tierData = tierCustomers.map((arr, idx) => {
+          const endVar = TIER_COLOR_VARS[idx];
+          const startVar = lighterVar(endVar);
+          const startColor = getCssVar(startVar, mrrCustRef.current!);
+          const endColor = getCssVar(endVar, mrrCustRef.current!);
+          const grad = ctx.createLinearGradient(0, 0, ctx.canvas.width, 0);
+          grad.addColorStop(0, startColor);
+          grad.addColorStop(1, endColor);
+          return {
+            label: `Tier ${idx + 1}`,
+            data: arr,
+            borderColor: grad,
+            legendColor: endColor,
+            borderWidth: 4,
+            yAxisID: "y2",
             pointRadius: 0,
             pointHoverRadius: 4,
             tension: 0.16,
-            fill: true,
-            order: -1,
-          },
-          ...tierCustomers.map((arr, idx) => {
-            const endVar = TIER_COLOR_VARS[idx];
-            const startVar = lighterVar(endVar);
-            const startColor = getCssVar(startVar, mrrCustRef.current!);
-            const endColor = getCssVar(endVar, mrrCustRef.current!);
-            const grad = ctx.createLinearGradient(0, 0, ctx.canvas.width, 0);
-            grad.addColorStop(0, startColor);
-            grad.addColorStop(1, endColor);
-            return {
-              label: `Tier ${idx + 1}`,
-              data: arr,
-              borderColor: grad,
-              borderWidth: 4,
-              yAxisID: "y2",
-              pointRadius: 0,
-              pointHoverRadius: 4,
-              tension: 0.16,
-              fill: false,
-            };
-          }),
-        ];
+            fill: false,
+            order: idx + 1,
+          };
+        });
+        const mrrDataset = {
+          label: "MRR",
+          data: mrrArr,
+          borderColor: mrrColor,
+          backgroundColor: mrrColor,
+          legendColor: mrrColor,
+          borderWidth: 2,
+          yAxisID: "y1",
+          pointRadius: 0,
+          pointHoverRadius: 4,
+          tension: 0.16,
+          fill: true,
+          order: -1,
+        };
+        const datasets = [...tierData, mrrDataset];
         if (!chartInstances.current.combined) {
           chartInstances.current.combined = new Chart(ctx, {
             type: "line",

--- a/frontend/src/utils/chartLegend.ts
+++ b/frontend/src/utils/chartLegend.ts
@@ -1,7 +1,9 @@
 export function generateLegend(chart: import("chart.js").Chart): string {
   const { datasets } = chart.data;
   const items = datasets.map((ds: any) => {
-    const color = ds.borderColor || ds.backgroundColor || "#000";
+    const rawColor =
+      ds.legendColor || ds.borderColor || ds.backgroundColor || "#000";
+    const color = typeof rawColor === "string" ? rawColor : "#000";
     const label = ds.label || "";
     return `<span style="display:inline-flex;align-items:center;margin-right:8px;">
       <span style="background-color:${color};width:10px;height:10px;display:inline-block;margin-right:4px;"></span>${label}


### PR DESCRIPTION
## Summary
- place MRR dataset at the end of the dataset list so it appears last in the legend
- keep drawing order so tier lines render above MRR

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx', jinja2 must be installed)*
- `npm test` *(fails: jest not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.