### PR TITLE
Fix MRR dataset order

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -306,7 +306,7 @@ export default function Dashboard() {
           pointHoverRadius: 4,
           tension: 0.16,
           fill: true,
-          order: -1,
+          order: tierCustomers.length + 1,
         };
         const datasets = [...tierData, mrrDataset];
         if (!chartInstances.current.combined) {


### PR DESCRIPTION
## Summary
- keep tier datasets ordered 1..n
- draw MRR dataset after tiers for correct layering

## Testing
- `pytest` *(fails: No module named 'httpx', jinja2 must be installed)*
- `npm test` *(fails: jest: not found)*