### PR TITLE
Fix squidInk chart color

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -275,6 +275,7 @@ export default function Dashboard() {
           "--color-driftwood-200",
           mrrCustRef.current!,
         );
+        const squidInk = getCssVar("--squid-ink", mrrCustRef.current!);
         const tierData = tierCustomers.map((arr, idx) => {
           const endVar = TIER_COLOR_VARS[idx];
           const startVar = lighterVar(endVar);


### PR DESCRIPTION
## Summary
- define `squidInk` color in Dashboard chart setup

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test` in `frontend/` *(fails: jest not found)*