### PR TITLE
Fix world globe graticule

### DIFF
--- a/frontend/src/components/WorldGlobe.tsx
+++ b/frontend/src/components/WorldGlobe.tsx
@@ -26,14 +26,12 @@ function Graticule() {
   const lines = geoGraticule().step([15, 15])();
   const positions: number[] = [];
 
-  lines.coordinates.forEach((multi) => {
-    multi.forEach((coords) => {
-      for (let i = 0; i < coords.length - 1; i++) {
-        const a = project(coords[i]);
-        const b = project(coords[i + 1]);
-        positions.push(a.x, a.y, a.z, b.x, b.y, b.z);
-      }
-    });
+  lines.coordinates.forEach((coords) => {
+    for (let i = 0; i < coords.length - 1; i++) {
+      const a = project(coords[i]);
+      const b = project(coords[i + 1]);
+      positions.push(a.x, a.y, a.z, b.x, b.y, b.z);
+    }
   });
 
   const geom = new BufferGeometry();


### PR DESCRIPTION
## Summary
- fix graticule construction in `WorldGlobe` so coordinate pairs are handled correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', AssertionError: jinja2 must be installed)*
- `npm test --silent` *(fails: jest: not found)*