### PR TITLE
Enhance MRR chart

### DIFF
--- a/frontend/src/Dashboard.tsx
+++ b/frontend/src/Dashboard.tsx
@@ -291,7 +291,8 @@ export default function Dashboard() {
             yAxisID: "y2",
             pointRadius: 0,
             pointHoverRadius: 4,
-            tension: 0.16,
+            tension: 0.4,
+            cubicInterpolationMode: "monotone" as const,
             fill: false,
             order: idx + 1,
           };
@@ -306,8 +307,9 @@ export default function Dashboard() {
           yAxisID: "y1",
           pointRadius: 0,
           pointHoverRadius: 4,
-          tension: 0.16,
-          fill: true,
+          tension: 0.4,
+          cubicInterpolationMode: "monotone" as const,
+          fill: false,
           order: tierCustomers.length + 1,
         };
         const datasets = [...tierData, mrrDataset];
@@ -344,7 +346,12 @@ export default function Dashboard() {
         } else {
           const ch = chartInstances.current.combined;
           ch.data.labels = labels;
-          ch.data.datasets = datasets as any;
+          tierData.forEach((d, idx) => {
+            Object.assign(ch.data.datasets[idx], d, { data: d.data });
+          });
+          Object.assign(ch.data.datasets[tierData.length], mrrDataset, {
+            data: mrrDataset.data,
+          });
           ch.update();
         }
         if (chartInstances.current.combined) {

--- a/frontend/src/chartConfig.ts
+++ b/frontend/src/chartConfig.ts
@@ -1,20 +1,23 @@
-import { Chart } from 'chart.js/auto';
+import { Chart } from "chart.js/auto";
+import endLine from "./plugins/endLine";
 
 export function setupChartDefaults() {
   const styles = getComputedStyle(document.documentElement);
-  const gridColor = styles.getPropertyValue('--color-neutral-200') || '#CAC9C5';
-  const textColor = styles.getPropertyValue('--color-neutral-900') || '#1E1D1B';
-  const tooltipBg = styles.getPropertyValue('--color-neutral-900') || '#1E1D1B';
-  const tooltipText = styles.getPropertyValue('--color-neutral-50') || '#FDFCFA';
+  const gridColor = styles.getPropertyValue("--color-neutral-200") || "#CAC9C5";
+  const textColor = styles.getPropertyValue("--color-neutral-900") || "#1E1D1B";
+  const tooltipBg = styles.getPropertyValue("--color-neutral-900") || "#1E1D1B";
+  const tooltipText =
+    styles.getPropertyValue("--color-neutral-50") || "#FDFCFA";
 
   Chart.defaults.color = textColor.trim();
-  Chart.defaults.font.family = 'Roboto Mono, monospace';
+  Chart.defaults.font.family = "Roboto Mono, monospace";
   Chart.defaults.elements.line.borderWidth = 4;
-  Chart.defaults.elements.line.borderCapStyle = 'round';
+  Chart.defaults.elements.line.borderCapStyle = "round";
   Chart.defaults.elements.line.fill = false;
   Chart.defaults.elements.line.pointRadius = 0;
   Chart.defaults.elements.bar.borderRadius = 8;
   Chart.defaults.datasets.bar.categoryPercentage = 0.8;
+  Chart.register(endLine);
   Chart.defaults.plugins.legend.display = true;
   Chart.defaults.plugins.tooltip.backgroundColor = tooltipBg.trim();
   Chart.defaults.plugins.tooltip.titleColor = tooltipText.trim();

--- a/frontend/src/plugins/endLine.ts
+++ b/frontend/src/plugins/endLine.ts
@@ -1,0 +1,26 @@
+import { Chart } from "chart.js/auto";
+
+const endLine = {
+  id: "endLine",
+  afterDatasetsDraw(chart: Chart) {
+    const ctx = chart.ctx;
+    const mrrDataset = chart.data.datasets.find((d) => d.label === "MRR");
+    const yScale = chart.scales["y1"];
+    if (!ctx || !mrrDataset || !yScale) return;
+    const data = mrrDataset.data as number[];
+    if (!data.length) return;
+    const lastValue = data[data.length - 1] as number;
+    const y = yScale.getPixelForValue(lastValue);
+    if (!y) return;
+    ctx.save();
+    ctx.strokeStyle = (mrrDataset as any).borderColor || "#000";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(chart.chartArea.left, y);
+    ctx.lineTo(chart.chartArea.right, y);
+    ctx.stroke();
+    ctx.restore();
+  },
+};
+
+export default endLine;


### PR DESCRIPTION
## Summary
- smooth line charts using monotone cubic interpolation
- remove fill from the MRR line and keep smoothing consistent
- draw a horizontal line from the last MRR value across the chart
- register the custom endLine plugin for all charts

## Testing
- `pytest` *(fails: ModuleNotFoundError: httpx, jinja2 must be installed)*
- `npm test` *(fails: jest not found)*